### PR TITLE
Fix dev server import path

### DIFF
--- a/scripts/dev-server.ts
+++ b/scripts/dev-server.ts
@@ -1,8 +1,14 @@
-import { createServer } from '../services/api/src/index.ts';
+type ApiModule = typeof import('../services/api/src/index');
+
+async function loadApi(): Promise<ApiModule> {
+  const apiModuleUrl = new URL('../services/api/src/index.ts', import.meta.url);
+  return import(apiModuleUrl.href) as Promise<ApiModule>;
+}
 
 const port = Number(process.env.PORT ?? 3000);
 
 async function main() {
+  const { createServer } = await loadApi();
   const { app } = await createServer();
   app.listen(port, () => {
     console.log(`[dev] API server listening on http://localhost:${port}`);


### PR DESCRIPTION
## Summary
- fix the dev server to import the API service using a relative path so the module can be resolved without relying on tsconfig path aliases

## Testing
- pnpm dev *(fails: missing local dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d55abf15908333a994b188e44929e1