### PR TITLE
feat: scaffold multi-role web app shell

### DIFF
--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -1,0 +1,13 @@
+import { BrowserRouter } from 'react-router-dom';
+import { AppRoutes } from './routes';
+import { Providers } from './providers';
+
+export const App = () => (
+  <Providers>
+    <BrowserRouter>
+      <AppRoutes />
+    </BrowserRouter>
+  </Providers>
+);
+
+export default App;

--- a/apps/web/src/app/layouts/AppShell.tsx
+++ b/apps/web/src/app/layouts/AppShell.tsx
@@ -1,0 +1,32 @@
+import { NavLink, Outlet } from 'react-router-dom';
+import type { PropsWithChildren } from 'react';
+import './app-shell.css';
+
+const primaryNav = [
+  { to: '/student', label: '学生端' },
+  { to: '/teacher', label: '教师端' },
+  { to: '/parent', label: '家长端' },
+  { to: '/admin', label: '管理端' },
+];
+
+export const AppShell = ({ children }: PropsWithChildren) => (
+  <div className="app-shell">
+    <header className="app-shell__header">
+      <div className="app-shell__brand">代码奇兵 Code Adventurers</div>
+      <nav aria-label="角色切换">
+        <ul>
+          {primaryNav.map((item) => (
+            <li key={item.to}>
+              <NavLink to={item.to}>{item.label}</NavLink>
+            </li>
+          ))}
+        </ul>
+      </nav>
+      <div className="app-shell__actions">
+        <button type="button">消息中心</button>
+        <button type="button">账号</button>
+      </div>
+    </header>
+    <main className="app-shell__main">{children ?? <Outlet />}</main>
+  </div>
+);

--- a/apps/web/src/app/layouts/RoleLayout.tsx
+++ b/apps/web/src/app/layouts/RoleLayout.tsx
@@ -1,0 +1,46 @@
+import { NavLink, Outlet, useLocation } from 'react-router-dom';
+import type { PropsWithChildren, ReactNode } from 'react';
+import './role-layout.css';
+
+interface RoleRoute {
+  to: string;
+  label: string;
+}
+
+interface RoleLayoutProps {
+  title: string;
+  description: string;
+  routes: RoleRoute[];
+  cta?: ReactNode;
+}
+
+export const RoleLayout = ({ title, description, routes, cta, children }: PropsWithChildren<RoleLayoutProps>) => {
+  const location = useLocation();
+
+  return (
+    <div className="role-layout">
+      <aside className="role-layout__sidebar">
+        <div className="role-layout__hero">
+          <h1>{title}</h1>
+          <p>{description}</p>
+          {cta}
+        </div>
+        <nav>
+          <ul>
+            {routes.map((route) => (
+              <li key={route.to}>
+                <NavLink to={route.to} className={({ isActive }) => (isActive ? 'active' : undefined)}>
+                  {route.label}
+                </NavLink>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      </aside>
+      <section className="role-layout__content" aria-live="polite">
+        <div className="role-layout__breadcrumbs">当前路径：{location.pathname}</div>
+        {children ?? <Outlet />}
+      </section>
+    </div>
+  );
+};

--- a/apps/web/src/app/layouts/app-shell.css
+++ b/apps/web/src/app/layouts/app-shell.css
@@ -1,0 +1,60 @@
+.app-shell {
+  min-height: 100vh;
+  background: linear-gradient(180deg, #eef2ff 0%, #f8fafc 100%);
+  display: flex;
+  flex-direction: column;
+}
+
+.app-shell__header {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  padding: 1rem 2.5rem;
+  background: rgba(15, 23, 42, 0.85);
+  color: white;
+  position: sticky;
+  top: 0;
+  z-index: 900;
+}
+
+.app-shell__brand {
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.app-shell__header nav ul {
+  display: inline-flex;
+  gap: 1.5rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.app-shell__header a {
+  color: rgba(255, 255, 255, 0.8);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.app-shell__header a.active {
+  color: #ffffff;
+  text-decoration: underline;
+}
+
+.app-shell__actions {
+  display: inline-flex;
+  gap: 0.75rem;
+}
+
+.app-shell__actions button {
+  background: rgba(255, 255, 255, 0.12);
+  border: none;
+  border-radius: 999px;
+  padding: 0.5rem 1rem;
+  color: white;
+}
+
+.app-shell__main {
+  flex: 1;
+  padding: 2rem 3rem;
+}

--- a/apps/web/src/app/layouts/role-layout.css
+++ b/apps/web/src/app/layouts/role-layout.css
@@ -1,0 +1,58 @@
+.role-layout {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: 2rem;
+}
+
+.role-layout__sidebar {
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 1.5rem;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
+}
+
+.role-layout__hero h1 {
+  margin: 0;
+  font-size: 1.75rem;
+}
+
+.role-layout__hero p {
+  margin: 0.5rem 0 0;
+  color: #475569;
+}
+
+.role-layout__sidebar nav ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.role-layout__sidebar a {
+  display: block;
+  padding: 0.75rem 1rem;
+  border-radius: 1rem;
+  background: rgba(79, 70, 229, 0.08);
+  color: #4338ca;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.role-layout__sidebar a.active {
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  color: white;
+}
+
+.role-layout__content {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.role-layout__breadcrumbs {
+  font-size: 0.85rem;
+  color: #475569;
+}

--- a/apps/web/src/app/pages/admin/AdminLayout.tsx
+++ b/apps/web/src/app/pages/admin/AdminLayout.tsx
@@ -1,0 +1,14 @@
+import type { PropsWithChildren } from 'react';
+import { Card } from '../../../components/ui/Card';
+import './admin-layout.css';
+
+export const AdminLayout = ({ children }: PropsWithChildren) => (
+  <div className="admin-layout">
+    <Card title="系统健康" subtitle="监控、主题、开关一站式管理">
+      <p style={{ margin: 0 }}>LCP: 2.1s · INP: 180ms · 错误率：0.2%</p>
+    </Card>
+    {children}
+  </div>
+);
+
+export default AdminLayout;

--- a/apps/web/src/app/pages/admin/CurriculumPage.tsx
+++ b/apps/web/src/app/pages/admin/CurriculumPage.tsx
@@ -1,0 +1,12 @@
+import { Card } from '../../../components/ui/Card';
+import { Button } from '../../../components/ui/Button';
+import { EmptyState } from '../../../components/ui/EmptyState';
+
+const CurriculumPage = () => (
+  <Card title="课程/关卡大纲编辑器" subtitle="Page 级操作">
+    <EmptyState title="编辑器占位" description="预留可视化课程编辑器" />
+    <Button variant="primary">创建新章节</Button>
+  </Card>
+);
+
+export default CurriculumPage;

--- a/apps/web/src/app/pages/admin/OpsPage.tsx
+++ b/apps/web/src/app/pages/admin/OpsPage.tsx
@@ -1,0 +1,26 @@
+import { Card } from '../../../components/ui/Card';
+import { Table } from '../../../components/ui/Table';
+import { Button } from '../../../components/ui/Button';
+import { EmptyState } from '../../../components/ui/EmptyState';
+
+const ops = [
+  { id: 'banner1', name: '春季活动', status: '上线' },
+];
+
+const OpsPage = () => (
+  <Card title="运营位/公告">
+    <Table columns={['名称', '状态', '操作']} emptyState={<EmptyState title="暂无运营位" />}>
+      {ops.map((op) => (
+        <tr key={op.id}>
+          <td>{op.name}</td>
+          <td>{op.status}</td>
+          <td>
+            <Button variant="ghost">编辑</Button>
+          </td>
+        </tr>
+      ))}
+    </Table>
+  </Card>
+);
+
+export default OpsPage;

--- a/apps/web/src/app/pages/admin/OverviewPage.tsx
+++ b/apps/web/src/app/pages/admin/OverviewPage.tsx
@@ -1,0 +1,20 @@
+import { Card } from '../../../components/ui/Card';
+import { EmptyState } from '../../../components/ui/EmptyState';
+
+const OverviewPage = () => (
+  <div style={{ display: 'grid', gap: '1.5rem' }}>
+    <Card title="关键指标" subtitle="性能预算与错误监控">
+      <ul>
+        <li>FCP: 1.8s</li>
+        <li>LCP: 2.2s</li>
+        <li>INP: 180ms</li>
+        <li>错误率: 0.2%</li>
+      </ul>
+    </Card>
+    <Card title="待办事项">
+      <EmptyState title="暂无待办" description="所有任务均已完成" />
+    </Card>
+  </div>
+);
+
+export default OverviewPage;

--- a/apps/web/src/app/pages/admin/SettingsPage.tsx
+++ b/apps/web/src/app/pages/admin/SettingsPage.tsx
@@ -1,0 +1,41 @@
+import { useForm } from 'react-hook-form';
+import { Card } from '../../../components/ui/Card';
+import { Button } from '../../../components/ui/Button';
+import { Input } from '../../../components/ui/Input';
+
+interface AdminSettings {
+  theme: string;
+  maintenance: string;
+}
+
+const SettingsPage = () => {
+  const { register, handleSubmit } = useForm<AdminSettings>({
+    defaultValues: {
+      theme: 'default',
+      maintenance: 'off',
+    },
+  });
+
+  const onSubmit = (values: AdminSettings) => {
+    // eslint-disable-next-line no-console
+    console.log('保存站点设置', values);
+  };
+
+  return (
+    <Card title="站点设置" subtitle="主题 / 开关">
+      <form onSubmit={handleSubmit(onSubmit)} style={{ display: 'grid', gap: '1rem', maxWidth: '360px' }}>
+        <label>
+          <span>主题</span>
+          <Input {...register('theme')} />
+        </label>
+        <label>
+          <span>维护模式</span>
+          <Input {...register('maintenance')} />
+        </label>
+        <Button type="submit">保存</Button>
+      </form>
+    </Card>
+  );
+};
+
+export default SettingsPage;

--- a/apps/web/src/app/pages/admin/UsersPage.tsx
+++ b/apps/web/src/app/pages/admin/UsersPage.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import { Card } from '../../../components/ui/Card';
+import { Table } from '../../../components/ui/Table';
+import { Drawer } from '../../../components/ui/Drawer';
+import { Button } from '../../../components/ui/Button';
+import { EmptyState } from '../../../components/ui/EmptyState';
+
+const users = [
+  { id: 'u1', name: 'Admin', role: '管理员', status: '启用' },
+  { id: 'u2', name: 'TeacherA', role: '教师', status: '启用' },
+];
+
+const UsersPage = () => {
+  const [selected, setSelected] = useState<typeof users[number] | null>(null);
+
+  return (
+    <Card title="用户管理" subtitle="列表 → 详情 Drawer">
+      <Table columns={['名称', '角色', '状态', '操作']} emptyState={<EmptyState title="暂无用户" />}>
+        {users.map((user) => (
+          <tr key={user.id}>
+            <td>{user.name}</td>
+            <td>{user.role}</td>
+            <td>{user.status}</td>
+            <td>
+              <Button variant="ghost" onClick={() => setSelected(user)}>
+                查看详情
+              </Button>
+            </td>
+          </tr>
+        ))}
+      </Table>
+      <Drawer title="用户详情" open={Boolean(selected)} onClose={() => setSelected(null)}>
+        {selected ? (
+          <div style={{ display: 'grid', gap: '1rem' }}>
+            <h3>{selected.name}</h3>
+            <p>角色：{selected.role}</p>
+            <p>状态：{selected.status}</p>
+            <Button variant="danger">停用账号</Button>
+          </div>
+        ) : null}
+      </Drawer>
+    </Card>
+  );
+};
+
+export default UsersPage;

--- a/apps/web/src/app/pages/admin/admin-layout.css
+++ b/apps/web/src/app/pages/admin/admin-layout.css
@@ -1,0 +1,4 @@
+.admin-layout {
+  display: grid;
+  gap: 1.5rem;
+}

--- a/apps/web/src/app/pages/parent/HomePage.tsx
+++ b/apps/web/src/app/pages/parent/HomePage.tsx
@@ -1,0 +1,20 @@
+import { Card } from '../../../components/ui/Card';
+import { Progress } from '../../../components/ui/Progress';
+import { Button } from '../../../components/ui/Button';
+
+const HomePage = () => (
+  <div style={{ display: 'grid', gap: '1.5rem' }}>
+    <Card title="孩子进度" subtitle="近七日时长与待查看周报">
+      <Progress value={68} label="本周目标达成" />
+      <Button variant="secondary">查看周报</Button>
+    </Card>
+    <Card title="最近活动">
+      <ul>
+        <li>3 月 14 日：通关 2 关</li>
+        <li>3 月 13 日：练习 45 分钟</li>
+      </ul>
+    </Card>
+  </div>
+);
+
+export default HomePage;

--- a/apps/web/src/app/pages/parent/ParentLayout.tsx
+++ b/apps/web/src/app/pages/parent/ParentLayout.tsx
@@ -1,0 +1,15 @@
+import type { PropsWithChildren } from 'react';
+import { Card } from '../../../components/ui/Card';
+import { Badge } from '../../../components/ui/Badge';
+import './parent-layout.css';
+
+export const ParentLayout = ({ children }: PropsWithChildren) => (
+  <div className="parent-layout">
+    <Card title="家庭进度" subtitle="掌握孩子的学习节奏">
+      <Badge tone="info">周报待查看</Badge>
+    </Card>
+    {children}
+  </div>
+);
+
+export default ParentLayout;

--- a/apps/web/src/app/pages/parent/ProgressPage.tsx
+++ b/apps/web/src/app/pages/parent/ProgressPage.tsx
@@ -1,0 +1,29 @@
+import { useParams } from 'react-router-dom';
+import { Card } from '../../../components/ui/Card';
+import { Tabs, TabItem } from '../../../components/ui/Tabs';
+import { EmptyState } from '../../../components/ui/EmptyState';
+
+const ProgressPage = () => {
+  const { childId } = useParams();
+
+  return (
+    <Card title={`孩子 ${childId}`} subtitle="进度详情 / 关卡清单 / 错题集">
+      <Tabs>
+        <TabItem id="curve" title="进度曲线">
+          <EmptyState title="曲线图占位" description="等待数据接入" />
+        </TabItem>
+        <TabItem id="levels" title="关卡清单">
+          <ul>
+            <li>森林启程 - 已完成</li>
+            <li>火山挑战 - 练习中</li>
+          </ul>
+        </TabItem>
+        <TabItem id="mistakes" title="错题集">
+          <p>暂无错题，保持努力！</p>
+        </TabItem>
+      </Tabs>
+    </Card>
+  );
+};
+
+export default ProgressPage;

--- a/apps/web/src/app/pages/parent/SettingsPage.tsx
+++ b/apps/web/src/app/pages/parent/SettingsPage.tsx
@@ -1,0 +1,41 @@
+import { useForm } from 'react-hook-form';
+import { Card } from '../../../components/ui/Card';
+import { Button } from '../../../components/ui/Button';
+import { Input } from '../../../components/ui/Input';
+
+interface ParentSettings {
+  reminderTime: string;
+  weeklyReport: string;
+}
+
+const SettingsPage = () => {
+  const { register, handleSubmit } = useForm<ParentSettings>({
+    defaultValues: {
+      reminderTime: '20:00',
+      weeklyReport: '周日',
+    },
+  });
+
+  const onSubmit = (values: ParentSettings) => {
+    // eslint-disable-next-line no-console
+    console.log('保存家长设置', values);
+  };
+
+  return (
+    <Card title="家长设置" subtitle="提醒与家长控制">
+      <form onSubmit={handleSubmit(onSubmit)} style={{ display: 'grid', gap: '1rem', maxWidth: '360px' }}>
+        <label>
+          <span>每日提醒时间</span>
+          <Input type="time" {...register('reminderTime')} />
+        </label>
+        <label>
+          <span>周报发送日</span>
+          <Input {...register('weeklyReport')} />
+        </label>
+        <Button type="submit">保存</Button>
+      </form>
+    </Card>
+  );
+};
+
+export default SettingsPage;

--- a/apps/web/src/app/pages/parent/parent-layout.css
+++ b/apps/web/src/app/pages/parent/parent-layout.css
@@ -1,0 +1,4 @@
+.parent-layout {
+  display: grid;
+  gap: 1.5rem;
+}

--- a/apps/web/src/app/pages/shared/AuthPage.tsx
+++ b/apps/web/src/app/pages/shared/AuthPage.tsx
@@ -1,0 +1,23 @@
+import { Card } from '../../../components/ui/Card';
+import { Button } from '../../../components/ui/Button';
+import { Input } from '../../../components/ui/Input';
+
+const AuthPage = () => (
+  <div style={{ display: 'grid', placeItems: 'center', minHeight: '60vh' }}>
+    <Card title="登录" subtitle="统一认证入口">
+      <form style={{ display: 'grid', gap: '1rem', width: '320px' }}>
+        <label>
+          <span>邮箱</span>
+          <Input type="email" placeholder="name@example.com" />
+        </label>
+        <label>
+          <span>密码</span>
+          <Input type="password" placeholder="••••••" />
+        </label>
+        <Button type="submit">登录</Button>
+      </form>
+    </Card>
+  </div>
+);
+
+export default AuthPage;

--- a/apps/web/src/app/pages/student/AchievementsPage.tsx
+++ b/apps/web/src/app/pages/student/AchievementsPage.tsx
@@ -1,0 +1,29 @@
+import { Card } from '../../../components/ui/Card';
+import { Badge } from '../../../components/ui/Badge';
+import { EmptyState } from '../../../components/ui/EmptyState';
+
+const achievements = [
+  { id: 'a1', name: '极速先锋', description: '首关通关 ≤ 45s', progress: 100 },
+  { id: 'a2', name: '连胜达人', description: '连续通关 5 天', progress: 60 },
+];
+
+const AchievementsPage = () => (
+  <div style={{ display: 'grid', gap: '1.5rem' }}>
+    {achievements.length ? (
+      achievements.map((achievement) => (
+        <Card
+          key={achievement.id}
+          title={achievement.name}
+          subtitle={achievement.description}
+          actions={<Badge tone={achievement.progress === 100 ? 'success' : 'info'}>{achievement.progress}%</Badge>}
+        >
+          <p>距离升级还需 {Math.max(0, 100 - achievement.progress)}%</p>
+        </Card>
+      ))
+    ) : (
+      <EmptyState title="暂无成就" description="完成挑战解锁更多徽章" />
+    )}
+  </div>
+);
+
+export default AchievementsPage;

--- a/apps/web/src/app/pages/student/HomePage.tsx
+++ b/apps/web/src/app/pages/student/HomePage.tsx
@@ -1,0 +1,46 @@
+import { Card } from '../../../components/ui/Card';
+import { Button } from '../../../components/ui/Button';
+import { Progress } from '../../../components/ui/Progress';
+import { Badge } from '../../../components/ui/Badge';
+import { EmptyState } from '../../../components/ui/EmptyState';
+
+const mockLevels = [
+  { id: '1', title: '基础动作', stars: 3, time: '32s' },
+  { id: '2', title: '循环进阶', stars: 2, time: '54s' },
+];
+
+const HomePage = () => (
+  <div className="student-home" style={{ display: 'grid', gap: '1.5rem' }}>
+    <Card
+      title="继续挑战"
+      subtitle="挑战最新开放的章节，保持 streak！"
+      actions={<Button>进入挑战器</Button>}
+    >
+      <Progress value={45} label="本周进度" />
+      <div style={{ display: 'flex', gap: '1rem' }}>
+        <Badge tone="success">今日连胜 +1</Badge>
+        <Badge tone="info">收藏关卡 5</Badge>
+      </div>
+    </Card>
+
+    <Card title="历史挑战记录">
+      {mockLevels.length ? (
+        <ul style={{ margin: 0, padding: 0, listStyle: 'none', display: 'grid', gap: '0.75rem' }}>
+          {mockLevels.map((level) => (
+            <li key={level.id} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+              <div>
+                <strong>{level.title}</strong>
+                <span style={{ marginLeft: '0.5rem', color: '#64748b' }}>⭐ {level.stars}</span>
+              </div>
+              <span>{level.time}</span>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <EmptyState title="还没有闯关记录" description="先去地图挑一关试试吧" />
+      )}
+    </Card>
+  </div>
+);
+
+export default HomePage;

--- a/apps/web/src/app/pages/student/LevelDetailPage.tsx
+++ b/apps/web/src/app/pages/student/LevelDetailPage.tsx
@@ -1,0 +1,35 @@
+import { useParams } from 'react-router-dom';
+import { Card } from '../../../components/ui/Card';
+import { Tabs, TabItem } from '../../../components/ui/Tabs';
+import { Button } from '../../../components/ui/Button';
+
+const LevelDetailPage = () => {
+  const { levelId } = useParams();
+
+  return (
+    <Card
+      title={`关卡 ${levelId}`}
+      subtitle="目标、可用积木与教学漫画一屏掌握"
+      actions={<Button variant="primary">进入挑战</Button>}
+    >
+      <Tabs>
+        <TabItem id="goal" title="目标">
+          <p>达成指定路径并在 60 步内完成。</p>
+        </TabItem>
+        <TabItem id="blocks" title="可用积木">
+          <ul>
+            <li>前进</li>
+            <li>向左/向右转</li>
+            <li>重复循环</li>
+            <li>条件判断</li>
+          </ul>
+        </TabItem>
+        <TabItem id="comic" title="教学漫画">
+          <p>漫画占位：讲述小机器人如何学会循环的故事。</p>
+        </TabItem>
+      </Tabs>
+    </Card>
+  );
+};
+
+export default LevelDetailPage;

--- a/apps/web/src/app/pages/student/LevelsPage.tsx
+++ b/apps/web/src/app/pages/student/LevelsPage.tsx
@@ -1,0 +1,58 @@
+import { useMemo, useState } from 'react';
+import { Card } from '../../../components/ui/Card';
+import { Select } from '../../../components/ui/Select';
+import { Badge } from '../../../components/ui/Badge';
+import { Button } from '../../../components/ui/Button';
+
+const allLevels = [
+  { id: 'l1', name: '探索森林', status: 'unlocked', stars: 0 },
+  { id: 'l2', name: '暗影城堡', status: 'locked', stars: 0 },
+  { id: 'l3', name: '火山挑战', status: 'completed', stars: 3 },
+];
+
+const filters = [
+  { value: 'all', label: '全部' },
+  { value: 'completed', label: '已解' },
+  { value: 'unlocked', label: '未解' },
+  { value: 'favorite', label: '收藏' },
+];
+
+const LevelsPage = () => {
+  const [filter, setFilter] = useState('all');
+
+  const visibleLevels = useMemo(() => {
+    if (filter === 'all') return allLevels;
+    return allLevels.filter((level) => level.status === filter);
+  }, [filter]);
+
+  return (
+    <div style={{ display: 'grid', gap: '1.5rem' }}>
+      <Card title="章节地图" subtitle="按筛选查看当前章节的关卡进度">
+        <Select value={filter} onChange={(event) => setFilter(event.target.value)} aria-label="筛选关卡">
+          {filters.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </Select>
+      </Card>
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: '1.25rem' }}>
+        {visibleLevels.map((level) => (
+          <Card
+            key={level.id}
+            title={level.name}
+            subtitle={level.status === 'locked' ? '未解锁' : '挑战中'}
+            actions={<Button variant="primary">{level.status === 'locked' ? '待解锁' : '进入准备页'}</Button>}
+          >
+            <Badge tone={level.status === 'completed' ? 'success' : level.status === 'locked' ? 'warning' : 'info'}>
+              {level.status === 'completed' ? `⭐ ${level.stars}` : level.status === 'locked' ? '锁定' : '可挑战'}
+            </Badge>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default LevelsPage;

--- a/apps/web/src/app/pages/student/PlayPage.tsx
+++ b/apps/web/src/app/pages/student/PlayPage.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { Card } from '../../../components/ui/Card';
+import { Button } from '../../../components/ui/Button';
+import { Modal } from '../../../components/ui/Modal';
+
+const PlayPage = () => {
+  const { levelId } = useParams();
+  const [showHint, setShowHint] = useState(false);
+  const [attempts, setAttempts] = useState(0);
+
+  return (
+    <div style={{ display: 'grid', gap: '1.5rem' }}>
+      <Card title={`挑战器 - 关卡 ${levelId}`} subtitle="场景 / 积木库 / 程序区 / 目标">
+        <div style={{ display: 'grid', gridTemplateColumns: '2fr 1fr', gap: '1.5rem' }}>
+          <div style={{ minHeight: '280px', background: 'rgba(15, 23, 42, 0.9)', borderRadius: '1rem' }}>
+            <p style={{ color: 'white', padding: '1rem' }}>3D 场景占位</p>
+          </div>
+          <div style={{ display: 'grid', gap: '1rem' }}>
+            <section>
+              <h3>积木库</h3>
+              <p>拖拽积木到程序区构建算法。</p>
+            </section>
+            <section>
+              <h3>目标说明</h3>
+              <p>在 60 步内收集所有能源块。</p>
+            </section>
+          </div>
+        </div>
+        <div style={{ display: 'flex', gap: '1rem', justifyContent: 'flex-end' }}>
+          <Button variant="secondary" onClick={() => setShowHint(true)}>
+            查看 Hint
+          </Button>
+          <Button variant="primary" onClick={() => setAttempts((prev) => prev + 1)}>
+            运行程序
+          </Button>
+        </div>
+      </Card>
+
+      <Card title="失败分类提示" subtitle="自动识别错误并给出建议">
+        <ul style={{ margin: 0, padding: 0, listStyle: 'none', display: 'grid', gap: '0.5rem' }}>
+          <li>· 路径偏移：请检查第 12 步的转向。</li>
+          <li>· 循环次数不足：考虑使用重复 4 次的循环。</li>
+          <li>· 条件判断缺失：使用 if 判断能量块是否存在。</li>
+        </ul>
+        <p>尝试次数：{attempts}</p>
+      </Card>
+
+      <Modal
+        title="Hint 分级策略"
+        open={showHint}
+        onClose={() => setShowHint(false)}
+        primaryAction={{ label: '明白了', onClick: () => setShowHint(false) }}
+      >
+        <ol>
+          <li>Hint 1：观察目标格子中的颜色变化。</li>
+          <li>Hint 2：尝试将重复动作包裹在循环中。</li>
+          <li>Hint 3：当能量块缺失时，使用条件判断跳出循环。</li>
+        </ol>
+      </Modal>
+    </div>
+  );
+};
+
+export default PlayPage;

--- a/apps/web/src/app/pages/student/ResultPage.tsx
+++ b/apps/web/src/app/pages/student/ResultPage.tsx
@@ -1,0 +1,28 @@
+import { Card } from '../../../components/ui/Card';
+import { Button } from '../../../components/ui/Button';
+import { Badge } from '../../../components/ui/Badge';
+import { Progress } from '../../../components/ui/Progress';
+
+const ResultPage = () => (
+  <div style={{ display: 'grid', gap: '1.5rem' }}>
+    <Card title="结算" subtitle="星级 / 奖励 / 最佳差距 / 下一步">
+      <div style={{ display: 'flex', gap: '1.5rem', alignItems: 'center' }}>
+        <Badge tone="success" style={{ fontSize: '1.5rem' }}>
+          ⭐⭐⭐
+        </Badge>
+        <div>
+          <p style={{ margin: 0 }}>获得奖励：500 XP + 稀有积木</p>
+          <p style={{ margin: 0 }}>最佳差距：比最佳记录多 4 步</p>
+        </div>
+      </div>
+      <Progress value={72} label="下一颗星进度" />
+      <div style={{ display: 'flex', gap: '1rem' }}>
+        <Button variant="primary">挑战下一关</Button>
+        <Button variant="secondary">回放</Button>
+        <Button variant="ghost">分享战报</Button>
+      </div>
+    </Card>
+  </div>
+);
+
+export default ResultPage;

--- a/apps/web/src/app/pages/student/SettingsPage.tsx
+++ b/apps/web/src/app/pages/student/SettingsPage.tsx
@@ -1,0 +1,62 @@
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Card } from '../../../components/ui/Card';
+import { Button } from '../../../components/ui/Button';
+import { Input } from '../../../components/ui/Input';
+import { Select } from '../../../components/ui/Select';
+
+const settingsSchema = z.object({
+  displayName: z.string().min(2, '昵称至少两个字符'),
+  language: z.string(),
+  enableVoice: z.boolean().default(true),
+});
+
+type SettingsForm = z.infer<typeof settingsSchema>;
+
+const SettingsPage = () => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<SettingsForm>({
+    resolver: zodResolver(settingsSchema),
+    defaultValues: {
+      displayName: '像素冒险家',
+      language: 'zh-CN',
+      enableVoice: true,
+    },
+  });
+
+  const onSubmit = (values: SettingsForm) => {
+    // eslint-disable-next-line no-console
+    console.log('保存设置', values);
+  };
+
+  return (
+    <Card title="学生设置" subtitle="调节语音提示、语言、昵称等">
+      <form onSubmit={handleSubmit(onSubmit)} style={{ display: 'grid', gap: '1rem', maxWidth: '420px' }}>
+        <label>
+          <span>昵称</span>
+          <Input {...register('displayName')} />
+          {errors.displayName ? <span style={{ color: '#ef4444' }}>{errors.displayName.message}</span> : null}
+        </label>
+        <label>
+          <span>界面语言</span>
+          <Select {...register('language')}>
+            <option value="zh-CN">中文</option>
+            <option value="en-US">English</option>
+          </Select>
+        </label>
+        <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+          <input type="checkbox" {...register('enableVoice')} /> 启用语音提示
+        </label>
+        <Button type="submit" disabled={isSubmitting}>
+          保存设置
+        </Button>
+      </form>
+    </Card>
+  );
+};
+
+export default SettingsPage;

--- a/apps/web/src/app/pages/student/StudentLayout.tsx
+++ b/apps/web/src/app/pages/student/StudentLayout.tsx
@@ -1,0 +1,80 @@
+import type { PropsWithChildren } from 'react';
+import { useState } from 'react';
+import { Drawer } from '../../../components/ui/Drawer';
+import { Modal } from '../../../components/ui/Modal';
+import { Button } from '../../../components/ui/Button';
+import { Tabs, TabItem } from '../../../components/ui/Tabs';
+import { Badge } from '../../../components/ui/Badge';
+import { useFeatureFlags } from '../../providers/FeatureFlagProvider';
+import './student-layout.css';
+
+export const StudentLayout = ({ children }: PropsWithChildren) => {
+  const { flags } = useFeatureFlags();
+  const [showAchievementDrawer, setShowAchievementDrawer] = useState(false);
+  const [showExitConfirm, setShowExitConfirm] = useState(false);
+
+  return (
+    <div className="student-layout">
+      <div className="student-layout__meta">
+        <div>
+          <h2>今日冒险进度</h2>
+          <Badge tone="info">首关目标 ≤ 60s</Badge>
+        </div>
+        <div className="student-layout__meta-actions">
+          <Button variant="secondary" onClick={() => setShowAchievementDrawer(true)}>
+            成就抽屉
+          </Button>
+          <Button variant="ghost" onClick={() => setShowExitConfirm(true)}>
+            退出挑战
+          </Button>
+        </div>
+      </div>
+      <Tabs defaultTab="overview">
+        <TabItem id="overview" title="冒险概览">
+          <div className="student-layout__content">{children}</div>
+        </TabItem>
+        <TabItem id="upcoming" title="下一步提示">
+          <div className="student-layout__hints">
+            <p>Hint 1：先观察目标图形，确定边缘积木。</p>
+            <p>Hint 2：尝试使用循环积木减少重复。</p>
+            <p>Hint 3：使用条件判断来控制方向。</p>
+          </div>
+        </TabItem>
+      </Tabs>
+
+      <Drawer
+        title="成就与装扮"
+        open={showAchievementDrawer}
+        onClose={() => setShowAchievementDrawer(false)}
+        width={flags['student.drawer.wide'] ? 640 : 520}
+      >
+        <div className="student-layout__drawer">
+          <section>
+            <h3>最新成就</h3>
+            <ul>
+              <li>🔥 连续通关 3 天</li>
+              <li>⭐ 本周获得 12 颗星</li>
+              <li>🎨 解锁新头像：像素机械师</li>
+            </ul>
+          </section>
+          <section>
+            <h3>装扮选择</h3>
+            <div className="student-layout__skins">正在开发中的装扮选择体验…</div>
+          </section>
+        </div>
+      </Drawer>
+
+      <Modal
+        title="确认退出挑战？"
+        open={showExitConfirm}
+        onClose={() => setShowExitConfirm(false)}
+        primaryAction={{ label: '确认退出', onClick: () => setShowExitConfirm(false) }}
+        secondaryAction={{ label: '继续冒险', onClick: () => setShowExitConfirm(false) }}
+      >
+        <p>退出后将丢失当前尝试的进度，但保留已解锁的提示。</p>
+      </Modal>
+    </div>
+  );
+};
+
+export default StudentLayout;

--- a/apps/web/src/app/pages/student/student-layout.css
+++ b/apps/web/src/app/pages/student/student-layout.css
@@ -1,0 +1,53 @@
+.student-layout {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.student-layout__meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: rgba(79, 70, 229, 0.1);
+  border-radius: 1rem;
+  padding: 1.25rem 1.5rem;
+}
+
+.student-layout__meta h2 {
+  margin: 0;
+}
+
+.student-layout__meta-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.student-layout__content {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.student-layout__hints {
+  display: grid;
+  gap: 0.5rem;
+  color: #475569;
+}
+
+.student-layout__drawer {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.student-layout__drawer ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.student-layout__skins {
+  padding: 1rem;
+  border: 1px dashed rgba(99, 102, 241, 0.3);
+  border-radius: 1rem;
+  text-align: center;
+}

--- a/apps/web/src/app/pages/teacher/AnalyticsPage.tsx
+++ b/apps/web/src/app/pages/teacher/AnalyticsPage.tsx
@@ -1,0 +1,18 @@
+import { Card } from '../../../components/ui/Card';
+import { EmptyState } from '../../../components/ui/EmptyState';
+
+const AnalyticsPage = () => (
+  <div style={{ display: 'grid', gap: '1.5rem' }}>
+    <Card title="概念热力图">
+      <EmptyState title="等待数据接入" description="此处将展示概念掌握情况" />
+    </Card>
+    <Card title="卡关榜">
+      <EmptyState title="暂无数据" description="上线后将展示卡关关卡" />
+    </Card>
+    <Card title="用时分析">
+      <EmptyState title="敬请期待" description="预留图表组件占位" />
+    </Card>
+  </div>
+);
+
+export default AnalyticsPage;

--- a/apps/web/src/app/pages/teacher/AssignmentsPage.tsx
+++ b/apps/web/src/app/pages/teacher/AssignmentsPage.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import { Card } from '../../../components/ui/Card';
+import { Table } from '../../../components/ui/Table';
+import { Button } from '../../../components/ui/Button';
+import { Modal } from '../../../components/ui/Modal';
+import { EmptyState } from '../../../components/ui/EmptyState';
+
+const assignments = [
+  { id: 'a1', title: '第 5 章 循环', due: '3 月 18 日', status: '进行中' },
+];
+
+const AssignmentsPage = () => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Card title="作业列表" subtitle="统一模板：搜索区 + 表格 + 详情 / 批量布置">
+      <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '1rem' }}>
+        <div />
+        <Button onClick={() => setOpen(true)}>批量布置</Button>
+      </div>
+      <Table columns={['作业名称', '截止时间', '状态', '操作']} emptyState={<EmptyState title="暂无作业" />}>
+        {assignments.map((item) => (
+          <tr key={item.id}>
+            <td>{item.title}</td>
+            <td>{item.due}</td>
+            <td>{item.status}</td>
+            <td>
+              <Button variant="ghost">查看详情</Button>
+            </td>
+          </tr>
+        ))}
+      </Table>
+      <Modal
+        title="批量布置作业"
+        open={open}
+        onClose={() => setOpen(false)}
+        primaryAction={{ label: '确认布置', onClick: () => setOpen(false) }}
+        secondaryAction={{ label: '取消', onClick: () => setOpen(false) }}
+      >
+        <p>选择班级后即可批量布置该作业。</p>
+      </Modal>
+    </Card>
+  );
+};
+
+export default AssignmentsPage;

--- a/apps/web/src/app/pages/teacher/ClassDetailPage.tsx
+++ b/apps/web/src/app/pages/teacher/ClassDetailPage.tsx
@@ -1,0 +1,38 @@
+import { useParams } from 'react-router-dom';
+import { Card } from '../../../components/ui/Card';
+import { Tabs, TabItem } from '../../../components/ui/Tabs';
+import { Table } from '../../../components/ui/Table';
+
+const ClassDetailPage = () => {
+  const { classId } = useParams();
+
+  return (
+    <Card title={`班级 ${classId}`} subtitle="成员 / 成绩 / 日志">
+      <Tabs>
+        <TabItem id="members" title="成员">
+          <Table columns={['姓名', '进度']}>
+            <tr>
+              <td>林小小</td>
+              <td>88%</td>
+            </tr>
+            <tr>
+              <td>张星星</td>
+              <td>92%</td>
+            </tr>
+          </Table>
+        </TabItem>
+        <TabItem id="scores" title="成绩">
+          <p>成绩分布图占位，等待接入数据。</p>
+        </TabItem>
+        <TabItem id="logs" title="日志">
+          <ul>
+            <li>2024-03-14 09:00 发布作业</li>
+            <li>2024-03-14 21:00 自动提醒未完成学生</li>
+          </ul>
+        </TabItem>
+      </Tabs>
+    </Card>
+  );
+};
+
+export default ClassDetailPage;

--- a/apps/web/src/app/pages/teacher/ClassesPage.tsx
+++ b/apps/web/src/app/pages/teacher/ClassesPage.tsx
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+import { Card } from '../../../components/ui/Card';
+import { Table } from '../../../components/ui/Table';
+import { Input } from '../../../components/ui/Input';
+import { Button } from '../../../components/ui/Button';
+import { Drawer } from '../../../components/ui/Drawer';
+import { EmptyState } from '../../../components/ui/EmptyState';
+
+const mockClasses = [
+  { id: 'c1', name: '五年级 1 班', students: 32, progress: '78%' },
+  { id: 'c2', name: '五年级 2 班', students: 28, progress: '84%' },
+];
+
+const ClassesPage = () => {
+  const [keyword, setKeyword] = useState('');
+  const [selectedClass, setSelectedClass] = useState<typeof mockClasses[number] | null>(null);
+
+  const filtered = mockClasses.filter((item) => item.name.includes(keyword));
+
+  return (
+    <Card title="班级列表" subtitle="搜索 + 表格 + 详情 Drawer">
+      <div style={{ display: 'flex', gap: '1rem', marginBottom: '1rem' }}>
+        <Input placeholder="搜索班级" value={keyword} onChange={(event) => setKeyword(event.target.value)} />
+        <Button variant="secondary">导出</Button>
+      </div>
+      <Table columns={['班级名称', '学生数', '平均进度', '操作']} emptyState={<EmptyState title="暂无班级" />}>
+        {filtered.length ? (
+          filtered.map((item) => (
+            <tr key={item.id}>
+              <td>{item.name}</td>
+              <td>{item.students}</td>
+              <td>{item.progress}</td>
+              <td>
+                <Button variant="ghost" onClick={() => setSelectedClass(item)}>
+                  查看详情
+                </Button>
+              </td>
+            </tr>
+          ))
+        ) : (
+          <tr>
+            <td colSpan={4}>
+              <EmptyState title="未找到班级" />
+            </td>
+          </tr>
+        )}
+      </Table>
+
+      <Drawer title="班级详情" open={Boolean(selectedClass)} onClose={() => setSelectedClass(null)}>
+        {selectedClass ? (
+          <div style={{ display: 'grid', gap: '1rem' }}>
+            <h3>{selectedClass.name}</h3>
+            <p>学生数：{selectedClass.students}</p>
+            <p>平均进度：{selectedClass.progress}</p>
+          </div>
+        ) : null}
+      </Drawer>
+    </Card>
+  );
+};
+
+export default ClassesPage;

--- a/apps/web/src/app/pages/teacher/ContentPage.tsx
+++ b/apps/web/src/app/pages/teacher/ContentPage.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import { Card } from '../../../components/ui/Card';
+import { Table } from '../../../components/ui/Table';
+import { Drawer } from '../../../components/ui/Drawer';
+import { Button } from '../../../components/ui/Button';
+import { EmptyState } from '../../../components/ui/EmptyState';
+
+const contents = [
+  { id: 'level-101', title: '迷宫指挥官', type: '关卡', status: '上线' },
+  { id: 'level-102', title: '循环工坊', type: '关卡', status: '灰度' },
+];
+
+const ContentPage = () => {
+  const [selected, setSelected] = useState<typeof contents[number] | null>(null);
+
+  return (
+    <Card title="内容库" subtitle="树 + 列表 + 详情 Drawer">
+      <Table columns={['名称', '类型', '状态', '操作']} emptyState={<EmptyState title="暂无内容" />}>
+        {contents.map((item) => (
+          <tr key={item.id}>
+            <td>{item.title}</td>
+            <td>{item.type}</td>
+            <td>{item.status}</td>
+            <td>
+              <Button variant="ghost" onClick={() => setSelected(item)}>
+                查看详情
+              </Button>
+            </td>
+          </tr>
+        ))}
+      </Table>
+      <Drawer title="内容详情" open={Boolean(selected)} onClose={() => setSelected(null)}>
+        {selected ? (
+          <div style={{ display: 'grid', gap: '1rem' }}>
+            <h3>{selected.title}</h3>
+            <p>类型：{selected.type}</p>
+            <p>状态：{selected.status}</p>
+            <Button variant="primary">编辑内容</Button>
+          </div>
+        ) : null}
+      </Drawer>
+    </Card>
+  );
+};
+
+export default ContentPage;

--- a/apps/web/src/app/pages/teacher/OverviewPage.tsx
+++ b/apps/web/src/app/pages/teacher/OverviewPage.tsx
@@ -1,0 +1,25 @@
+import { Card } from '../../../components/ui/Card';
+import { EmptyState } from '../../../components/ui/EmptyState';
+
+const OverviewPage = () => (
+  <div style={{ display: 'grid', gap: '1.5rem' }}>
+    <Card title="今日看板" subtitle="班级、作业、内容库概览">
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: '1rem' }}>
+        <Card title="班级" subtitle="共 4 个活跃班级">
+          <p>待处理申请：2</p>
+        </Card>
+        <Card title="作业" subtitle="本周布置 6 份">
+          <p>平均完成率：82%</p>
+        </Card>
+        <Card title="内容库" subtitle="新增关卡 3 个">
+          <p>审核中：1</p>
+        </Card>
+      </div>
+    </Card>
+    <Card title="教学分析" subtitle="概念热力 / 卡关榜 / 用时">
+      <EmptyState title="等待接入后端数据" description="预留接口适配层" />
+    </Card>
+  </div>
+);
+
+export default OverviewPage;

--- a/apps/web/src/app/pages/teacher/TeacherLayout.tsx
+++ b/apps/web/src/app/pages/teacher/TeacherLayout.tsx
@@ -1,0 +1,37 @@
+import type { PropsWithChildren } from 'react';
+import { useState } from 'react';
+import { Drawer } from '../../../components/ui/Drawer';
+import { Button } from '../../../components/ui/Button';
+import { Badge } from '../../../components/ui/Badge';
+import { useFeatureFlags } from '../../providers/FeatureFlagProvider';
+import './teacher-layout.css';
+
+export const TeacherLayout = ({ children }: PropsWithChildren) => {
+  const { flags } = useFeatureFlags();
+  const [openDrawer, setOpenDrawer] = useState(false);
+
+  return (
+    <div className="teacher-layout">
+      <header>
+        <h2>教学作战室</h2>
+        <div>
+          <Badge tone="info">灰度中</Badge>
+          <Button variant="secondary" onClick={() => setOpenDrawer(true)}>
+            详情抽屉
+          </Button>
+        </div>
+      </header>
+      <div>{children}</div>
+      <Drawer
+        title="班级概览"
+        open={openDrawer}
+        onClose={() => setOpenDrawer(false)}
+        width={flags['teacher.drawer.wide'] ? 640 : 520}
+      >
+        <p>抽屉内可查看班级详情、成绩分布与日志。</p>
+      </Drawer>
+    </div>
+  );
+};
+
+export default TeacherLayout;

--- a/apps/web/src/app/pages/teacher/teacher-layout.css
+++ b/apps/web/src/app/pages/teacher/teacher-layout.css
@@ -1,0 +1,23 @@
+.teacher-layout {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.teacher-layout header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: rgba(236, 72, 153, 0.12);
+  border-radius: 1rem;
+  padding: 1.25rem 1.5rem;
+}
+
+.teacher-layout header h2 {
+  margin: 0;
+}
+
+.teacher-layout header div {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+}

--- a/apps/web/src/app/providers.tsx
+++ b/apps/web/src/app/providers.tsx
@@ -1,0 +1,38 @@
+import type { PropsWithChildren, ReactNode } from 'react';
+import { Suspense, useMemo } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+
+import { ToastProvider } from '../components/ui/Toast';
+import { FeatureFlagProvider } from './providers/FeatureFlagProvider';
+import { AppErrorBoundary } from './providers/AppErrorBoundary';
+
+export const Providers = ({ children }: PropsWithChildren): ReactNode => {
+  const queryClient = useMemo(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            refetchOnWindowFocus: false,
+            retry: 1,
+          },
+        },
+      }),
+    [],
+  );
+
+  return (
+    <AppErrorBoundary>
+      <QueryClientProvider client={queryClient}>
+        <FeatureFlagProvider>
+          <ToastProvider>
+            <Suspense fallback={<div role="status">正在加载体验...</div>}>
+              {children}
+            </Suspense>
+          </ToastProvider>
+        </FeatureFlagProvider>
+        {process.env.NODE_ENV !== 'production' ? <ReactQueryDevtools initialIsOpen={false} /> : null}
+      </QueryClientProvider>
+    </AppErrorBoundary>
+  );
+};

--- a/apps/web/src/app/providers/AppErrorBoundary.tsx
+++ b/apps/web/src/app/providers/AppErrorBoundary.tsx
@@ -1,0 +1,44 @@
+import type { ErrorInfo, PropsWithChildren, ReactNode } from 'react';
+import { Component } from 'react';
+
+import { Button } from '../../components/ui/Button';
+
+interface AppErrorBoundaryState {
+  hasError: boolean;
+}
+
+export class AppErrorBoundary extends Component<PropsWithChildren, AppErrorBoundaryState> {
+  state: AppErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): AppErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    if (process.env.NODE_ENV !== 'production') {
+      // eslint-disable-next-line no-console
+      console.error('Uncaught error in AppErrorBoundary', error, info);
+    }
+  }
+
+  private handleReset = () => {
+    this.setState({ hasError: false });
+    window.location.reload();
+  };
+
+  override render(): ReactNode {
+    if (this.state.hasError) {
+      return (
+        <div role="alert" style={{ padding: '2rem', textAlign: 'center' }}>
+          <h1>糟糕，体验出了点问题</h1>
+          <p>请尝试刷新页面，如果问题持续出现请联系支持团队。</p>
+          <Button variant="primary" onClick={this.handleReset}>
+            刷新页面
+          </Button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/apps/web/src/app/providers/FeatureFlagProvider.tsx
+++ b/apps/web/src/app/providers/FeatureFlagProvider.tsx
@@ -1,0 +1,51 @@
+import { createContext, useContext, useMemo, useState } from 'react';
+import type { PropsWithChildren, ReactNode } from 'react';
+
+import { defaultFlags } from '../../utils/featureFlags';
+
+type FlagMap = Record<string, boolean>;
+
+interface FeatureFlagContextValue {
+  flags: FlagMap;
+  setFlag: (flag: string, value: boolean) => void;
+}
+
+const FeatureFlagContext = createContext<FeatureFlagContextValue | undefined>(undefined);
+
+export const FeatureFlagProvider = ({ children }: PropsWithChildren): ReactNode => {
+  const [flags, setFlags] = useState<FlagMap>(defaultFlags);
+
+  const value = useMemo<FeatureFlagContextValue>(
+    () => ({
+      flags,
+      setFlag: (flag, value) =>
+        setFlags((prev) => ({
+          ...prev,
+          [flag]: value,
+        })),
+    }),
+    [flags],
+  );
+
+  return <FeatureFlagContext.Provider value={value}>{children}</FeatureFlagContext.Provider>;
+};
+
+export const useFeatureFlag = (flag: string): boolean => {
+  const context = useContext(FeatureFlagContext);
+
+  if (!context) {
+    throw new Error('useFeatureFlag must be used within FeatureFlagProvider');
+  }
+
+  return context.flags[flag] ?? false;
+};
+
+export const useFeatureFlags = (): FeatureFlagContextValue => {
+  const context = useContext(FeatureFlagContext);
+
+  if (!context) {
+    throw new Error('useFeatureFlags must be used within FeatureFlagProvider');
+  }
+
+  return context;
+};

--- a/apps/web/src/app/routes.tsx
+++ b/apps/web/src/app/routes.tsx
@@ -1,0 +1,170 @@
+import { lazy } from 'react';
+import { Navigate, Outlet, useRoutes } from 'react-router-dom';
+
+import { AppShell } from './layouts/AppShell';
+import { RoleLayout } from './layouts/RoleLayout';
+import { StudentLayout } from './pages/student/StudentLayout';
+import { TeacherLayout } from './pages/teacher/TeacherLayout';
+import { ParentLayout } from './pages/parent/ParentLayout';
+import { AdminLayout } from './pages/admin/AdminLayout';
+
+const StudentHomePage = lazy(() => import('./pages/student/HomePage'));
+const StudentLevelsPage = lazy(() => import('./pages/student/LevelsPage'));
+const StudentLevelDetailPage = lazy(() => import('./pages/student/LevelDetailPage'));
+const StudentPlayPage = lazy(() => import('./pages/student/PlayPage'));
+const StudentResultPage = lazy(() => import('./pages/student/ResultPage'));
+const StudentAchievementsPage = lazy(() => import('./pages/student/AchievementsPage'));
+const StudentSettingsPage = lazy(() => import('./pages/student/SettingsPage'));
+
+const TeacherOverviewPage = lazy(() => import('./pages/teacher/OverviewPage'));
+const TeacherClassesPage = lazy(() => import('./pages/teacher/ClassesPage'));
+const TeacherClassDetailPage = lazy(() => import('./pages/teacher/ClassDetailPage'));
+const TeacherAssignmentsPage = lazy(() => import('./pages/teacher/AssignmentsPage'));
+const TeacherContentPage = lazy(() => import('./pages/teacher/ContentPage'));
+const TeacherAnalyticsPage = lazy(() => import('./pages/teacher/AnalyticsPage'));
+
+const ParentHomePage = lazy(() => import('./pages/parent/HomePage'));
+const ParentProgressPage = lazy(() => import('./pages/parent/ProgressPage'));
+const ParentSettingsPage = lazy(() => import('./pages/parent/SettingsPage'));
+
+const AdminOverviewPage = lazy(() => import('./pages/admin/OverviewPage'));
+const AdminUsersPage = lazy(() => import('./pages/admin/UsersPage'));
+const AdminCurriculumPage = lazy(() => import('./pages/admin/CurriculumPage'));
+const AdminOpsPage = lazy(() => import('./pages/admin/OpsPage'));
+const AdminSettingsPage = lazy(() => import('./pages/admin/SettingsPage'));
+
+const AuthPlaceholder = lazy(() => import('./pages/shared/AuthPage'));
+
+const NotFoundPage = () => (
+  <div role="alert">
+    <h1>未找到页面</h1>
+    <p>请检查链接或返回主页。</p>
+  </div>
+);
+
+const StudentRoutes = () => (
+  <RoleLayout
+    title="学生冒险"
+    description="从地图到挑战再到成就收集的一站式体验"
+    routes={[
+      { to: '/student', label: '首页' },
+      { to: '/student/levels', label: '章节地图' },
+      { to: '/student/achievements', label: '成就' },
+      { to: '/student/settings', label: '设置' },
+    ]}
+  >
+    <StudentLayout>
+      <Outlet />
+    </StudentLayout>
+  </RoleLayout>
+);
+
+const TeacherRoutes = () => (
+  <RoleLayout
+    title="教师指挥台"
+    description="班级、作业、内容库与教学分析一体化"
+    routes={[
+      { to: '/teacher', label: '概览' },
+      { to: '/teacher/classes', label: '班级列表' },
+      { to: '/teacher/assignments', label: '作业布置' },
+      { to: '/teacher/content', label: '内容库' },
+      { to: '/teacher/analytics', label: '教学分析' },
+    ]}
+  >
+    <TeacherLayout>
+      <Outlet />
+    </TeacherLayout>
+  </RoleLayout>
+);
+
+const ParentRoutes = () => (
+  <RoleLayout
+    title="家长关怀"
+    description="掌握孩子进度、练习记录与家庭设置"
+    routes={[
+      { to: '/parent', label: '首页' },
+      { to: '/parent/progress/child-1', label: '进度详情' },
+      { to: '/parent/settings', label: '家长设置' },
+    ]}
+  >
+    <ParentLayout>
+      <Outlet />
+    </ParentLayout>
+  </RoleLayout>
+);
+
+const AdminRoutes = () => (
+  <RoleLayout
+    title="管理控制台"
+    description="站点治理、课程编排与运营配置"
+    routes={[
+      { to: '/admin', label: '概览' },
+      { to: '/admin/users', label: '用户与角色' },
+      { to: '/admin/curriculum', label: '课程大纲' },
+      { to: '/admin/ops', label: '运营位' },
+      { to: '/admin/settings', label: '站点设置' },
+    ]}
+  >
+    <AdminLayout>
+      <Outlet />
+    </AdminLayout>
+  </RoleLayout>
+);
+
+export const AppRoutes = () =>
+  useRoutes([
+    {
+      path: '/',
+      element: <AppShell />,
+      children: [
+        { index: true, element: <Navigate to="/student" replace /> },
+        { path: 'auth/*', element: <AuthPlaceholder /> },
+        {
+          path: 'student',
+          element: <StudentRoutes />,
+          children: [
+            { index: true, element: <StudentHomePage /> },
+            { path: 'levels', element: <StudentLevelsPage /> },
+            { path: 'levels/:levelId', element: <StudentLevelDetailPage /> },
+            { path: 'play/:levelId', element: <StudentPlayPage /> },
+            { path: 'result', element: <StudentResultPage /> },
+            { path: 'achievements', element: <StudentAchievementsPage /> },
+            { path: 'settings', element: <StudentSettingsPage /> },
+          ],
+        },
+        {
+          path: 'teacher',
+          element: <TeacherRoutes />,
+          children: [
+            { index: true, element: <TeacherOverviewPage /> },
+            { path: 'classes', element: <TeacherClassesPage /> },
+            { path: 'classes/:classId', element: <TeacherClassDetailPage /> },
+            { path: 'assignments', element: <TeacherAssignmentsPage /> },
+            { path: 'content', element: <TeacherContentPage /> },
+            { path: 'analytics', element: <TeacherAnalyticsPage /> },
+          ],
+        },
+        {
+          path: 'parent',
+          element: <ParentRoutes />,
+          children: [
+            { index: true, element: <ParentHomePage /> },
+            { path: 'progress/:childId', element: <ParentProgressPage /> },
+            { path: 'settings', element: <ParentSettingsPage /> },
+          ],
+        },
+        {
+          path: 'admin',
+          element: <AdminRoutes />,
+          children: [
+            { index: true, element: <AdminOverviewPage /> },
+            { path: 'users', element: <AdminUsersPage /> },
+            { path: 'curriculum', element: <AdminCurriculumPage /> },
+            { path: 'ops', element: <AdminOpsPage /> },
+            { path: 'settings', element: <AdminSettingsPage /> },
+          ],
+        },
+      ],
+    },
+    { path: '*', element: <NotFoundPage /> },
+  ]);

--- a/apps/web/src/components/ui/Badge.tsx
+++ b/apps/web/src/components/ui/Badge.tsx
@@ -1,0 +1,15 @@
+import type { PropsWithChildren } from 'react';
+import clsx from 'clsx';
+import './badge.css';
+
+type BadgeTone = 'default' | 'success' | 'warning' | 'danger' | 'info';
+
+interface BadgeProps {
+  tone?: BadgeTone;
+  pill?: boolean;
+  className?: string;
+}
+
+export const Badge = ({ tone = 'default', pill = true, className, children }: PropsWithChildren<BadgeProps>) => (
+  <span className={clsx('ui-badge', `ui-badge--${tone}`, { 'ui-badge--pill': pill }, className)}>{children}</span>
+);

--- a/apps/web/src/components/ui/Button.tsx
+++ b/apps/web/src/components/ui/Button.tsx
@@ -1,0 +1,30 @@
+import type { ButtonHTMLAttributes, PropsWithChildren } from 'react';
+import clsx from 'clsx';
+
+import './button.css';
+
+type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger';
+type ButtonSize = 'sm' | 'md' | 'lg';
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  loading?: boolean;
+}
+
+export const Button = ({
+  children,
+  variant = 'primary',
+  size = 'md',
+  loading = false,
+  disabled,
+  ...rest
+}: PropsWithChildren<ButtonProps>) => (
+  <button
+    className={clsx('ui-button', `ui-button--${variant}`, `ui-button--${size}`)}
+    disabled={loading || disabled}
+    {...rest}
+  >
+    {loading ? '处理中…' : children}
+  </button>
+);

--- a/apps/web/src/components/ui/Card.tsx
+++ b/apps/web/src/components/ui/Card.tsx
@@ -1,0 +1,26 @@
+import type { PropsWithChildren, ReactNode } from 'react';
+import clsx from 'clsx';
+
+import './card.css';
+
+export interface CardProps {
+  title?: ReactNode;
+  subtitle?: ReactNode;
+  actions?: ReactNode;
+  className?: string;
+}
+
+export const Card = ({ children, title, subtitle, actions, className }: PropsWithChildren<CardProps>) => (
+  <section className={clsx('ui-card', className)}>
+    {(title || subtitle || actions) && (
+      <header className="ui-card__header">
+        <div>
+          {typeof title === 'string' ? <h2>{title}</h2> : title}
+          {subtitle ? <p className="ui-card__subtitle">{subtitle}</p> : null}
+        </div>
+        {actions ? <div className="ui-card__actions">{actions}</div> : null}
+      </header>
+    )}
+    <div className="ui-card__content">{children}</div>
+  </section>
+);

--- a/apps/web/src/components/ui/Drawer.tsx
+++ b/apps/web/src/components/ui/Drawer.tsx
@@ -1,0 +1,49 @@
+import type { PropsWithChildren, ReactNode } from 'react';
+import { useEffect } from 'react';
+
+import { Button } from './Button';
+import './drawer.css';
+
+interface DrawerProps {
+  title: ReactNode;
+  open: boolean;
+  onClose: () => void;
+  width?: number;
+  footer?: ReactNode;
+}
+
+export const Drawer = ({ title, open, onClose, width = 520, footer, children }: PropsWithChildren<DrawerProps>) => {
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    if (open) {
+      document.addEventListener('keydown', handler);
+    }
+
+    return () => document.removeEventListener('keydown', handler);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <aside className="ui-drawer" role="complementary" aria-label={typeof title === 'string' ? title : undefined}>
+      <div className="ui-drawer__overlay" onClick={onClose} />
+      <div className="ui-drawer__panel" style={{ width }}>
+        <header className="ui-drawer__header">
+          <div>
+            {typeof title === 'string' ? <h2>{title}</h2> : title}
+          </div>
+          <Button variant="ghost" onClick={onClose} aria-label="关闭抽屉">
+            关闭
+          </Button>
+        </header>
+        <div className="ui-drawer__body">{children}</div>
+        {footer ? <footer className="ui-drawer__footer">{footer}</footer> : null}
+      </div>
+    </aside>
+  );
+};

--- a/apps/web/src/components/ui/EmptyState.tsx
+++ b/apps/web/src/components/ui/EmptyState.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from 'react';
+import './empty.css';
+
+interface EmptyStateProps {
+  icon?: ReactNode;
+  title: string;
+  description?: string;
+  action?: ReactNode;
+}
+
+export const EmptyState = ({ icon, title, description, action }: EmptyStateProps) => (
+  <div className="ui-empty" role="status">
+    {icon ? <div className="ui-empty__icon" aria-hidden>{icon}</div> : null}
+    <h3>{title}</h3>
+    {description ? <p>{description}</p> : null}
+    {action ? <div className="ui-empty__action">{action}</div> : null}
+  </div>
+);

--- a/apps/web/src/components/ui/Input.tsx
+++ b/apps/web/src/components/ui/Input.tsx
@@ -1,0 +1,6 @@
+import type { InputHTMLAttributes } from 'react';
+import './input.css';
+
+export const Input = (props: InputHTMLAttributes<HTMLInputElement>) => (
+  <input className="ui-input" {...props} />
+);

--- a/apps/web/src/components/ui/Modal.tsx
+++ b/apps/web/src/components/ui/Modal.tsx
@@ -1,0 +1,65 @@
+import type { PropsWithChildren, ReactNode } from 'react';
+import { useEffect } from 'react';
+
+import { Button } from './Button';
+import './modal.css';
+
+export interface ModalProps {
+  title: ReactNode;
+  open: boolean;
+  onClose: () => void;
+  primaryAction?: { label: string; onClick: () => void; disabled?: boolean };
+  secondaryAction?: { label: string; onClick: () => void; disabled?: boolean };
+}
+
+export const Modal = ({
+  title,
+  open,
+  onClose,
+  primaryAction,
+  secondaryAction,
+  children,
+}: PropsWithChildren<ModalProps>) => {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    if (open) {
+      document.addEventListener('keydown', handleKeyDown);
+    }
+
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div className="ui-modal" role="dialog" aria-modal="true">
+      <div className="ui-modal__overlay" onClick={onClose} />
+      <div className="ui-modal__content" role="document">
+        <header className="ui-modal__header">
+          <h2>{title}</h2>
+          <button type="button" aria-label="关闭" onClick={onClose} className="ui-modal__close">
+            ×
+          </button>
+        </header>
+        <div className="ui-modal__body">{children}</div>
+        <footer className="ui-modal__footer">
+          {secondaryAction ? (
+            <Button variant="ghost" onClick={secondaryAction.onClick} disabled={secondaryAction.disabled}>
+              {secondaryAction.label}
+            </Button>
+          ) : null}
+          {primaryAction ? (
+            <Button onClick={primaryAction.onClick} disabled={primaryAction.disabled}>
+              {primaryAction.label}
+            </Button>
+          ) : null}
+        </footer>
+      </div>
+    </div>
+  );
+};

--- a/apps/web/src/components/ui/Progress.tsx
+++ b/apps/web/src/components/ui/Progress.tsx
@@ -1,0 +1,23 @@
+import './progress.css';
+
+interface ProgressProps {
+  value: number;
+  max?: number;
+  label?: string;
+}
+
+export const Progress = ({ value, max = 100, label }: ProgressProps) => {
+  const percentage = Math.min(100, Math.max(0, (value / max) * 100));
+
+  return (
+    <div className="ui-progress">
+      {label ? <span className="ui-progress__label">{label}</span> : null}
+      <div className="ui-progress__track">
+        <div className="ui-progress__indicator" style={{ width: `${percentage}%` }} aria-hidden />
+      </div>
+      <span className="ui-progress__value" aria-live="polite">
+        {Math.round(percentage)}%
+      </span>
+    </div>
+  );
+};

--- a/apps/web/src/components/ui/Select.tsx
+++ b/apps/web/src/components/ui/Select.tsx
@@ -1,0 +1,6 @@
+import type { SelectHTMLAttributes } from 'react';
+import './select.css';
+
+export const Select = (props: SelectHTMLAttributes<HTMLSelectElement>) => (
+  <select className="ui-select" {...props} />
+);

--- a/apps/web/src/components/ui/Skeleton.tsx
+++ b/apps/web/src/components/ui/Skeleton.tsx
@@ -1,0 +1,17 @@
+import clsx from 'clsx';
+import './skeleton.css';
+
+interface SkeletonProps {
+  height?: number | string;
+  width?: number | string;
+  circle?: boolean;
+  className?: string;
+}
+
+export const Skeleton = ({ height = 16, width = '100%', circle = false, className }: SkeletonProps) => (
+  <div
+    className={clsx('ui-skeleton', className, { 'ui-skeleton--circle': circle })}
+    style={{ height, width }}
+    aria-hidden
+  />
+);

--- a/apps/web/src/components/ui/Table.tsx
+++ b/apps/web/src/components/ui/Table.tsx
@@ -1,0 +1,26 @@
+import type { PropsWithChildren, ReactNode } from 'react';
+import './table.css';
+
+interface TableProps {
+  emptyState?: ReactNode;
+  columns: string[];
+}
+
+export const Table = ({ columns, emptyState, children }: PropsWithChildren<TableProps>) => (
+  <div className="ui-table__wrapper">
+    <table className="ui-table">
+      <thead>
+        <tr>
+          {columns.map((column) => (
+            <th key={column} scope="col">
+              {column}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {children ? children : <tr><td colSpan={columns.length}>{emptyState}</td></tr>}
+      </tbody>
+    </table>
+  </div>
+);

--- a/apps/web/src/components/ui/Tabs.tsx
+++ b/apps/web/src/components/ui/Tabs.tsx
@@ -1,0 +1,62 @@
+import type { PropsWithChildren, ReactNode } from 'react';
+import { Children, cloneElement, isValidElement, useMemo, useState } from 'react';
+import clsx from 'clsx';
+
+import './tabs.css';
+
+export interface TabItemProps {
+  id: string;
+  title: ReactNode;
+}
+
+export const TabItem = ({ children }: PropsWithChildren<TabItemProps>) => <>{children}</>;
+
+interface TabsProps {
+  defaultTab?: string;
+  onTabChange?: (tabId: string) => void;
+}
+
+export const Tabs = ({ children, defaultTab, onTabChange }: PropsWithChildren<TabsProps>) => {
+  const tabs = useMemo(
+    () =>
+      Children.toArray(children).filter(isValidElement).map((child) => ({
+        id: child.props.id as string,
+        title: child.props.title as ReactNode,
+        content: child,
+      })),
+    [children],
+  );
+
+  const [activeTab, setActiveTab] = useState(defaultTab ?? tabs[0]?.id);
+
+  const handleSelect = (tabId: string) => {
+    setActiveTab(tabId);
+    onTabChange?.(tabId);
+  };
+
+  return (
+    <div className="ui-tabs">
+      <div role="tablist" className="ui-tabs__list">
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            role="tab"
+            type="button"
+            className={clsx('ui-tabs__trigger', { 'is-active': tab.id === activeTab })}
+            aria-selected={tab.id === activeTab}
+            onClick={() => handleSelect(tab.id)}
+          >
+            {tab.title}
+          </button>
+        ))}
+      </div>
+      <div className="ui-tabs__content" role="tabpanel">
+        {tabs.map((tab) =>
+          tab.id === activeTab && isValidElement(tab.content)
+            ? cloneElement(tab.content, { key: tab.id })
+            : null,
+        )}
+      </div>
+    </div>
+  );
+};

--- a/apps/web/src/components/ui/Toast.tsx
+++ b/apps/web/src/components/ui/Toast.tsx
@@ -1,0 +1,61 @@
+import { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import type { PropsWithChildren, ReactNode } from 'react';
+import './toast.css';
+
+interface ToastMessage {
+  id: string;
+  title: string;
+  description?: string;
+  tone?: 'info' | 'success' | 'warning' | 'danger';
+}
+
+interface ToastContextValue {
+  toasts: ToastMessage[];
+  pushToast: (toast: Omit<ToastMessage, 'id'>) => void;
+  dismissToast: (id: string) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | undefined>(undefined);
+
+export const ToastProvider = ({ children }: PropsWithChildren): ReactNode => {
+  const [toasts, setToasts] = useState<ToastMessage[]>([]);
+
+  const pushToast = useCallback((toast: Omit<ToastMessage, 'id'>) => {
+    setToasts((prev) => [...prev, { ...toast, id: crypto.randomUUID() }]);
+  }, []);
+
+  const dismissToast = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((toast) => toast.id !== id));
+  }, []);
+
+  const value = useMemo<ToastContextValue>(() => ({ toasts, pushToast, dismissToast }), [dismissToast, pushToast, toasts]);
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <div className="ui-toast__stack" aria-live="polite">
+        {toasts.map((toast) => (
+          <div key={toast.id} className={`ui-toast ui-toast--${toast.tone ?? 'info'}`}>
+            <div>
+              <strong>{toast.title}</strong>
+              {toast.description ? <p>{toast.description}</p> : null}
+            </div>
+            <button type="button" onClick={() => dismissToast(toast.id)} aria-label="关闭提示">
+              ×
+            </button>
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+};
+
+export const useToast = (): Pick<ToastContextValue, 'pushToast'> => {
+  const context = useContext(ToastContext);
+
+  if (!context) {
+    throw new Error('useToast must be used within ToastProvider');
+  }
+
+  return { pushToast: context.pushToast };
+};

--- a/apps/web/src/components/ui/badge.css
+++ b/apps/web/src/components/ui/badge.css
@@ -1,0 +1,35 @@
+.ui-badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  padding: 0.3rem 0.6rem;
+  border-radius: 0.5rem;
+  background: rgba(99, 102, 241, 0.15);
+  color: #312e81;
+}
+
+.ui-badge--pill {
+  border-radius: 999px;
+}
+
+.ui-badge--success {
+  background: rgba(34, 197, 94, 0.15);
+  color: #166534;
+}
+
+.ui-badge--warning {
+  background: rgba(234, 179, 8, 0.15);
+  color: #92400e;
+}
+
+.ui-badge--danger {
+  background: rgba(239, 68, 68, 0.15);
+  color: #991b1b;
+}
+
+.ui-badge--info {
+  background: rgba(59, 130, 246, 0.15);
+  color: #1d4ed8;
+}

--- a/apps/web/src/components/ui/button.css
+++ b/apps/web/src/components/ui/button.css
@@ -1,0 +1,57 @@
+.ui-button {
+  border: none;
+  border-radius: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.ui-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.ui-button--primary {
+  background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);
+  color: white;
+  box-shadow: 0 10px 20px rgba(99, 102, 241, 0.25);
+}
+
+.ui-button--primary:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 24px rgba(99, 102, 241, 0.25);
+}
+
+.ui-button--secondary {
+  background: rgba(79, 70, 229, 0.12);
+  color: #312e81;
+}
+
+.ui-button--ghost {
+  background: transparent;
+  color: inherit;
+}
+
+.ui-button--danger {
+  background: linear-gradient(135deg, #f97316 0%, #ef4444 100%);
+  color: white;
+}
+
+.ui-button--sm {
+  padding: 0.4rem 0.9rem;
+  font-size: 0.85rem;
+}
+
+.ui-button--md {
+  padding: 0.6rem 1.4rem;
+  font-size: 1rem;
+}
+
+.ui-button--lg {
+  padding: 0.9rem 1.8rem;
+  font-size: 1.1rem;
+}

--- a/apps/web/src/components/ui/card.css
+++ b/apps/web/src/components/ui/card.css
@@ -1,0 +1,37 @@
+.ui-card {
+  background: white;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.ui-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.ui-card__header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.ui-card__subtitle {
+  margin: 0.25rem 0 0;
+  color: #475569;
+}
+
+.ui-card__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.ui-card__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}

--- a/apps/web/src/components/ui/drawer.css
+++ b/apps/web/src/components/ui/drawer.css
@@ -1,0 +1,41 @@
+.ui-drawer {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  justify-content: flex-end;
+  z-index: 999;
+}
+
+.ui-drawer__overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.35);
+}
+
+.ui-drawer__panel {
+  position: relative;
+  height: 100%;
+  background: #f8fafc;
+  padding: 2rem;
+  box-shadow: -20px 0 40px rgba(15, 23, 42, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.ui-drawer__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.ui-drawer__body {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.ui-drawer__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}

--- a/apps/web/src/components/ui/empty.css
+++ b/apps/web/src/components/ui/empty.css
@@ -1,0 +1,18 @@
+.ui-empty {
+  text-align: center;
+  padding: 2rem;
+  border-radius: 1rem;
+  background: rgba(148, 163, 184, 0.12);
+  color: #475569;
+  display: grid;
+  gap: 0.75rem;
+  justify-items: center;
+}
+
+.ui-empty__icon {
+  font-size: 2rem;
+}
+
+.ui-empty__action {
+  margin-top: 0.5rem;
+}

--- a/apps/web/src/components/ui/input.css
+++ b/apps/web/src/components/ui/input.css
@@ -1,0 +1,14 @@
+.ui-input {
+  width: 100%;
+  padding: 0.65rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  background: white;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ui-input:focus {
+  outline: none;
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.2);
+}

--- a/apps/web/src/components/ui/modal.css
+++ b/apps/web/src/components/ui/modal.css
@@ -1,0 +1,53 @@
+.ui-modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.ui-modal__overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.5);
+}
+
+.ui-modal__content {
+  position: relative;
+  width: min(90vw, 480px);
+  background: #ffffff;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.ui-modal__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.ui-modal__header h2 {
+  margin: 0;
+}
+
+.ui-modal__close {
+  border: none;
+  background: transparent;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.ui-modal__body {
+  color: #1f2937;
+}
+
+.ui-modal__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}

--- a/apps/web/src/components/ui/progress.css
+++ b/apps/web/src/components/ui/progress.css
@@ -1,0 +1,29 @@
+.ui-progress {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.ui-progress__track {
+  height: 0.6rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.3);
+  overflow: hidden;
+}
+
+.ui-progress__indicator {
+  height: 100%;
+  background: linear-gradient(135deg, #0ea5e9, #6366f1);
+  border-radius: inherit;
+}
+
+.ui-progress__label {
+  font-weight: 600;
+  color: #1e40af;
+}
+
+.ui-progress__value {
+  font-variant-numeric: tabular-nums;
+  color: #1e293b;
+}

--- a/apps/web/src/components/ui/select.css
+++ b/apps/web/src/components/ui/select.css
@@ -1,0 +1,19 @@
+.ui-select {
+  width: 100%;
+  padding: 0.65rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  background: white;
+  appearance: none;
+  background-image: linear-gradient(45deg, transparent 50%, #6366f1 50%),
+    linear-gradient(135deg, #6366f1 50%, transparent 50%);
+  background-position: calc(100% - 20px) calc(50% - 3px), calc(100% - 15px) calc(50% - 3px);
+  background-size: 6px 6px, 6px 6px;
+  background-repeat: no-repeat;
+}
+
+.ui-select:focus {
+  outline: none;
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.2);
+}

--- a/apps/web/src/components/ui/skeleton.css
+++ b/apps/web/src/components/ui/skeleton.css
@@ -1,0 +1,22 @@
+@keyframes skeletonPulse {
+  0% {
+    opacity: 0.5;
+  }
+  50% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0.5;
+  }
+}
+
+.ui-skeleton {
+  background: linear-gradient(90deg, #e2e8f0, #f1f5f9, #e2e8f0);
+  background-size: 200% 100%;
+  border-radius: 999px;
+  animation: skeletonPulse 1.8s ease infinite;
+}
+
+.ui-skeleton--circle {
+  border-radius: 9999px;
+}

--- a/apps/web/src/components/ui/table.css
+++ b/apps/web/src/components/ui/table.css
@@ -1,0 +1,35 @@
+.ui-table__wrapper {
+  width: 100%;
+  border-radius: 1rem;
+  overflow: hidden;
+  box-shadow: 0 8px 30px rgba(15, 23, 42, 0.1);
+}
+
+.ui-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: white;
+}
+
+.ui-table thead {
+  background: rgba(99, 102, 241, 0.12);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.75rem;
+  color: #312e81;
+}
+
+.ui-table th,
+.ui-table td {
+  padding: 0.9rem 1.2rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.ui-table tbody tr:hover {
+  background: rgba(241, 245, 249, 0.6);
+}
+
+.ui-table tbody tr:last-child td {
+  border-bottom: none;
+}

--- a/apps/web/src/components/ui/tabs.css
+++ b/apps/web/src/components/ui/tabs.css
@@ -1,0 +1,37 @@
+.ui-tabs {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.ui-tabs__list {
+  display: inline-flex;
+  gap: 0.5rem;
+  padding: 0.25rem;
+  border-radius: 999px;
+  background: rgba(79, 70, 229, 0.08);
+}
+
+.ui-tabs__trigger {
+  border: none;
+  background: transparent;
+  color: #4338ca;
+  padding: 0.5rem 1.25rem;
+  border-radius: 999px;
+  cursor: pointer;
+  font-weight: 600;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.ui-tabs__trigger.is-active {
+  background: white;
+  color: #1d4ed8;
+  box-shadow: 0 10px 30px rgba(59, 130, 246, 0.2);
+}
+
+.ui-tabs__content {
+  background: white;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.15);
+}

--- a/apps/web/src/components/ui/toast.css
+++ b/apps/web/src/components/ui/toast.css
@@ -1,0 +1,42 @@
+.ui-toast__stack {
+  position: fixed;
+  top: 1.5rem;
+  right: 1.5rem;
+  display: grid;
+  gap: 0.75rem;
+  z-index: 1200;
+}
+
+.ui-toast {
+  min-width: 240px;
+  padding: 1rem 1.25rem;
+  border-radius: 0.75rem;
+  background: white;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.2);
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.ui-toast button {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-size: 1.25rem;
+}
+
+.ui-toast--success {
+  border-left: 4px solid #22c55e;
+}
+
+.ui-toast--warning {
+  border-left: 4px solid #f59e0b;
+}
+
+.ui-toast--danger {
+  border-left: 4px solid #ef4444;
+}
+
+.ui-toast--info {
+  border-left: 4px solid #3b82f6;
+}

--- a/apps/web/src/hooks/useWebVitalsLogger.ts
+++ b/apps/web/src/hooks/useWebVitalsLogger.ts
@@ -1,0 +1,16 @@
+import { useEffect } from 'react';
+
+export const useWebVitalsLogger = () => {
+  useEffect(() => {
+    const handler = (event: Event) => {
+      // eslint-disable-next-line no-console
+      console.log('[WebVitals]', event.type);
+    };
+
+    window.addEventListener('fcp', handler as EventListener);
+
+    return () => {
+      window.removeEventListener('fcp', handler as EventListener);
+    };
+  }, []);
+};

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,0 +1,9 @@
+import { createRoot } from 'react-dom/client';
+import App from './app/App';
+
+const container = document.getElementById('root');
+
+if (container) {
+  const root = createRoot(container);
+  root.render(<App />);
+}

--- a/apps/web/src/services/api/client.ts
+++ b/apps/web/src/services/api/client.ts
@@ -1,0 +1,13 @@
+export interface ApiResponse<T> {
+  data: T;
+  error?: string;
+}
+
+export const apiClient = {
+  async get<T>(path: string): Promise<ApiResponse<T>> {
+    // 适配层：未来接入真实后端
+    // eslint-disable-next-line no-console
+    console.log('[API] GET', path);
+    return { data: {} as T };
+  },
+};

--- a/apps/web/src/store/usePlaybackStore.ts
+++ b/apps/web/src/store/usePlaybackStore.ts
@@ -1,0 +1,17 @@
+import { create } from 'zustand';
+
+interface PlaybackState {
+  playing: boolean;
+  currentStep: number;
+  setPlaying: (playing: boolean) => void;
+  setCurrentStep: (step: number) => void;
+  reset: () => void;
+}
+
+export const usePlaybackStore = create<PlaybackState>((set) => ({
+  playing: false,
+  currentStep: 0,
+  setPlaying: (playing) => set({ playing }),
+  setCurrentStep: (currentStep) => set({ currentStep }),
+  reset: () => set({ playing: false, currentStep: 0 }),
+}));

--- a/apps/web/src/utils/featureFlags.ts
+++ b/apps/web/src/utils/featureFlags.ts
@@ -1,0 +1,4 @@
+export const defaultFlags = {
+  'student.drawer.wide': false,
+  'teacher.drawer.wide': true,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,18 @@
       "name": "code-adventurers",
       "version": "1.0.0",
       "dependencies": {
+        "@hookform/resolvers": "^3.3.4",
+        "@tanstack/react-query": "^5.50.1",
+        "@tanstack/react-query-devtools": "^5.50.1",
+        "clsx": "^2.1.1",
         "express": "^4.18.2",
         "mysql2": "^3.15.1",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "react-hook-form": "^7.51.4",
+        "react-router-dom": "^6.23.1",
+        "zod": "^3.22.4",
+        "zustand": "^4.5.2"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.2",
@@ -625,6 +633,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.10.0.tgz",
+      "integrity": "sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react-hook-form": "^7.0.0"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1052,6 +1069,15 @@
         "@noble/hashes": "^1.1.5"
       }
     },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -1077,6 +1103,59 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.2.tgz",
+      "integrity": "sha512-k/TcR3YalnzibscALLwxeiLUub6jN5EDLwKDiO7q5f4ICEoptJ+n9+7vcEFy5/x/i6Q+Lb/tXrsKCggf5uQJXQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.90.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.90.1.tgz",
+      "integrity": "sha512-GtINOPjPUH0OegJExZ70UahT9ykmAhmtNVcmtdnOZbxLwT7R5OmRztR5Ahe3/Cu7LArEmR6/588tAycuaWb1xQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.90.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.2.tgz",
+      "integrity": "sha512-CLABiR+h5PYfOWr/z+vWFt5VsOA2ekQeRQBFSKlcoW6Ndx/f8rfyVmq4LbgOM4GG2qtxAxjLYLOpCNTYm4uKzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.90.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.90.2.tgz",
+      "integrity": "sha512-vAXJzZuBXtCQtrY3F/yUNJCV4obT/A/n81kb3+YqLbro5Z2+phdAbceO+deU3ywPw8B42oyJlp4FhO0SoivDFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.90.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.90.2",
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -1429,7 +1508,7 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -1450,7 +1529,7 @@
       "version": "18.3.24",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
       "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -2194,6 +2273,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -2412,7 +2500,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -5943,12 +6031,60 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.63.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.63.0.tgz",
+      "integrity": "sha512-ZwueDMvUeucovM2VjkCf7zIHcs1aAlDimZu2Hvel5C5907gUzMpm4xCrQXtRzCvsBqFjonB4m3x4LzCFI1ZKWA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -6961,6 +7097,15 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -7313,6 +7458,43 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -11,10 +11,18 @@
     "test:jest": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --runInBand"
   },
   "dependencies": {
+    "@hookform/resolvers": "^3.3.4",
+    "@tanstack/react-query": "^5.50.1",
+    "@tanstack/react-query-devtools": "^5.50.1",
+    "clsx": "^2.1.1",
     "express": "^4.18.2",
     "mysql2": "^3.15.1",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-hook-form": "^7.51.4",
+    "react-router-dom": "^6.23.1",
+    "zustand": "^4.5.2",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.2",


### PR DESCRIPTION
## Summary
- add a new apps/web app shell with unified role-based layouts and nested routing for student, teacher, parent, and admin journeys
- introduce a v1 design system covering buttons, tabs, modal, drawer, table, toast, and other primitives to support the new flows
- wire global providers for react-query, feature flags, toasts, and error boundaries alongside placeholder state/store and API adapters

## Testing
- npm test *(fails: existing Jest suites reference legacy module paths that no longer resolve; see test output for missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b779663083339e3a07bc81aeb52f