### PR TITLE
Implement student portal functionality

### DIFF
--- a/apps/web/src/app/pages/student/AchievementsPage.tsx
+++ b/apps/web/src/app/pages/student/AchievementsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Card } from '../../../components/ui/Card';
 import { Badge } from '../../../components/ui/Badge';
@@ -7,121 +7,163 @@ import { Progress } from '../../../components/ui/Progress';
 import { Skeleton } from '../../../components/ui/Skeleton';
 import { EmptyState } from '../../../components/ui/EmptyState';
 import { useAppStore } from '../../../store/useAppStore';
-import { StudentProfile } from '../../../services/api/client';
+import { StudentProfile, apiClient } from '../../../services/api/client';
 
-// 成就定义
 const ACHIEVEMENTS = [
-  { 
-    id: 'first-win', 
-    name: '初来乍到', 
-    description: '完成第一个关卡', 
+  {
+    id: 'first-win',
+    name: '初来乍到',
+    description: '完成第一个关卡',
     icon: '🎯',
-    requirement: (profile: StudentProfile) => 
-      Object.keys(profile.progress).length > 0
+    requirement: (profile: StudentProfile) => Object.keys(profile.progress).length > 0
   },
-  { 
-    id: 'perfect-score', 
-    name: '完美主义者', 
-    description: '在一个关卡中获得3星', 
+  {
+    id: 'perfect-score',
+    name: '完美主义者',
+    description: '在一个关卡中获得3星',
     icon: '⭐',
-    requirement: (profile: StudentProfile) => 
-      Object.values(profile.progress).some(record => record.stars === 3)
+    requirement: (profile: StudentProfile) => Object.values(profile.progress).some(record => record.stars === 3)
   },
-  { 
-    id: 'speed-runner', 
-    name: '速度之星', 
-    description: '在30秒内完成关卡', 
+  {
+    id: 'speed-runner',
+    name: '速度之星',
+    description: '在30秒内完成关卡',
     icon: '⚡',
-    requirement: (profile: StudentProfile) => 
-      Object.values(profile.progress).some(record => record.duration <= 30)
+    requirement: (profile: StudentProfile) => Object.values(profile.progress).some(record => record.duration <= 30)
   },
-  { 
-    id: 'persistent', 
-    name: '坚持不懈', 
-    description: '完成5个关卡', 
+  {
+    id: 'persistent',
+    name: '坚持不懈',
+    description: '完成5个关卡',
     icon: '🏆',
-    requirement: (profile: StudentProfile) => 
-      Object.keys(profile.progress).length >= 5
+    requirement: (profile: StudentProfile) => Object.keys(profile.progress).length >= 5
   },
-  { 
-    id: 'explorer', 
-    name: '探索者', 
-    description: '完成10个关卡', 
+  {
+    id: 'explorer',
+    name: '探索者',
+    description: '完成10个关卡',
     icon: '🗺️',
-    requirement: (profile: StudentProfile) => 
-      Object.keys(profile.progress).length >= 10
+    requirement: (profile: StudentProfile) => Object.keys(profile.progress).length >= 10
   },
-  { 
-    id: 'star-collector', 
-    name: '星星收集者', 
-    description: '收集50颗星星', 
+  {
+    id: 'star-collector',
+    name: '星星收集者',
+    description: '收集50颗星星',
     icon: '🌟',
-    requirement: (profile: StudentProfile) => 
-      Object.values(profile.progress).reduce((sum, record) => sum + record.stars, 0) >= 50
-  },
+    requirement: (profile: StudentProfile) => Object.values(profile.progress).reduce((sum, record) => sum + record.stars, 0) >= 50
+  }
 ];
 
-// 装扮定义
 const OUTFITS = [
-  { 
-    id: 'starter-cape', 
-    name: '新手斗篷', 
-    rarity: 'common', 
+  {
+    id: 'starter-cape',
+    name: '新手斗篷',
+    rarity: 'common',
     icon: '🧥',
     description: '每个冒险者的起点',
     unlockCondition: '默认装备'
   },
-  { 
-    id: 'wizard-hat', 
-    name: '智慧法帽', 
-    rarity: 'rare', 
+  {
+    id: 'wizard-hat',
+    name: '智慧法帽',
+    rarity: 'rare',
     icon: '🎩',
     description: '智者的象征',
     unlockCondition: '完成5个关卡'
   },
-  { 
-    id: 'dragon-armor', 
-    name: '龙鳞护甲', 
-    rarity: 'epic', 
+  {
+    id: 'dragon-armor',
+    name: '龙鳞护甲',
+    rarity: 'epic',
     icon: '🛡️',
     description: '传说中的护甲',
     unlockCondition: '获得30颗星星'
   },
-  { 
-    id: 'golden-crown', 
-    name: '黄金王冠', 
-    rarity: 'legendary', 
+  {
+    id: 'golden-crown',
+    name: '黄金王冠',
+    rarity: 'legendary',
     icon: '👑',
     description: '编程大师的荣耀',
     unlockCondition: '完成所有关卡'
-  },
+  }
 ];
+
+const dayInMs = 1000 * 60 * 60 * 24;
+
+const calculateStreak = (progress: StudentProfile['progress']) => {
+  const completions = Object.values(progress)
+    .map(record => new Date(record.completedAt ?? 0))
+    .filter(date => !Number.isNaN(date.getTime()))
+    .map(date => new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime())
+    .sort((a, b) => b - a);
+
+  if (completions.length === 0) {
+    return 0;
+  }
+
+  const uniqueDays = Array.from(new Set(completions));
+  const today = new Date();
+  const todayStart = new Date(today.getFullYear(), today.getMonth(), today.getDate()).getTime();
+  const firstDiff = Math.round((todayStart - uniqueDays[0]) / dayInMs);
+
+  if (firstDiff > 1) {
+    return 0;
+  }
+
+  let streak = 1;
+  let previousDay = uniqueDays[0];
+
+  for (let i = 1; i < uniqueDays.length; i += 1) {
+    const diff = Math.round((previousDay - uniqueDays[i]) / dayInMs);
+    if (diff === 1) {
+      streak += 1;
+      previousDay = uniqueDays[i];
+    } else if (diff > 1) {
+      break;
+    }
+  }
+
+  return streak;
+};
+
+const getRarityColor = (rarity: string) => {
+  switch (rarity) {
+    case 'common':
+      return { bg: '#f0fdf4', border: '#16a34a', text: '#15803d' };
+    case 'rare':
+      return { bg: '#dbeafe', border: '#2563eb', text: '#1e40af' };
+    case 'epic':
+      return { bg: '#fef3c7', border: '#d97706', text: '#92400e' };
+    case 'legendary':
+      return { bg: '#fce7f3', border: '#be185d', text: '#9d174d' };
+    default:
+      return { bg: '#f8fafc', border: '#64748b', text: '#475569' };
+  }
+};
 
 const AchievementsPage = () => {
   const navigate = useNavigate();
   const [selectedTab, setSelectedTab] = useState<'achievements' | 'outfits' | 'stats'>('achievements');
-  
-  const { 
-    user, 
+  const [studentProfile, setStudentProfile] = useState<StudentProfile | null>(null);
+  const [equipping, setEquipping] = useState<string | null>(null);
+
+  const {
+    user,
     chapters,
-    loading, 
-    error, 
-    isLoggedIn, 
+    loading,
+    error,
+    isLoggedIn,
     loadStudentData,
     loadChapters
   } = useAppStore();
-  
-  const [studentProfile, setStudentProfile] = useState<StudentProfile | null>(null);
 
-  // 重定向到登录页面如果未登录
   useEffect(() => {
     if (!isLoggedIn) {
       navigate('/auth');
-      return;
     }
   }, [isLoggedIn, navigate]);
 
-  // 加载数据
   useEffect(() => {
     if (isLoggedIn && user?.role === 'student') {
       loadStudentData();
@@ -129,53 +171,61 @@ const AchievementsPage = () => {
     }
   }, [isLoggedIn, user, loadStudentData, loadChapters]);
 
-  // 处理用户数据
   useEffect(() => {
     if (user && user.role === 'student') {
       setStudentProfile(user as StudentProfile);
     }
   }, [user]);
 
-  // 计算统计数据
-  const getStats = () => {
-    if (!studentProfile) return { completedLevels: 0, totalStars: 0, totalTime: 0, streak: 0 };
-    
+  const stats = useMemo(() => {
+    if (!studentProfile) {
+      return { completedLevels: 0, totalStars: 0, totalTime: 0, streak: 0 };
+    }
     const completedLevels = Object.keys(studentProfile.progress).length;
     const totalStars = Object.values(studentProfile.progress).reduce((sum, record) => sum + record.stars, 0);
     const totalTime = Object.values(studentProfile.progress).reduce((sum, record) => sum + (record.duration || 0), 0);
-    const streak = Math.floor(Math.random() * 7) + 1; // 模拟连续天数
-    
+    const streak = calculateStreak(studentProfile.progress);
     return { completedLevels, totalStars, totalTime, streak };
-  };
+  }, [studentProfile]);
 
-  // 计算等级和经验
-  const getLevelInfo = () => {
-    const stats = getStats();
+  const levelInfo = useMemo(() => {
     const level = Math.floor(stats.totalStars / 10) + 1;
     const currentExp = stats.totalStars % 10;
     const maxExp = 10;
     return { level, currentExp, maxExp, progress: (currentExp / maxExp) * 100 };
-  };
+  }, [stats.totalStars]);
 
-  // 检查成就是否解锁
-  const isAchievementUnlocked = (achievement: any) => {
+  const isAchievementUnlocked = (achievement: typeof ACHIEVEMENTS[number]) => {
     return studentProfile ? achievement.requirement(studentProfile) : false;
   };
 
-  // 检查装扮是否解锁
-  const isOutfitUnlocked = (outfit: any) => {
-    if (!studentProfile) return false;
-    return studentProfile.avatar.unlocked.includes(outfit.id);
+  const isOutfitUnlocked = (outfitId: string) => {
+    if (!studentProfile) {
+      return false;
+    }
+    return studentProfile.avatar.unlocked.includes(outfitId);
   };
 
-  // 获取装扮稀有度颜色
-  const getRarityColor = (rarity: string) => {
-    switch (rarity) {
-      case 'common': return { bg: '#f0fdf4', border: '#16a34a', text: '#15803d' };
-      case 'rare': return { bg: '#dbeafe', border: '#2563eb', text: '#1e40af' };
-      case 'epic': return { bg: '#fef3c7', border: '#d97706', text: '#92400e' };
-      case 'legendary': return { bg: '#fce7f3', border: '#be185d', text: '#9d174d' };
-      default: return { bg: '#f8fafc', border: '#64748b', text: '#475569' };
+  const handleEquipOutfit = async (outfitId: string) => {
+    if (!studentProfile || studentProfile.avatar.equipped === outfitId) {
+      return;
+    }
+    setEquipping(outfitId);
+    try {
+      const response = await apiClient.updateStudentAvatar(outfitId);
+      if (response.error) {
+        throw new Error(response.error);
+      }
+      if (response.data) {
+        setStudentProfile({
+          ...studentProfile,
+          avatar: response.data
+        });
+      }
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setEquipping(null);
     }
   };
 
@@ -197,378 +247,176 @@ const AchievementsPage = () => {
     );
   }
 
-  const stats = getStats();
-  const levelInfo = getLevelInfo();
-
   return (
     <div style={{ display: 'grid', gap: '1.5rem' }}>
-      {/* 角色展示卡片 */}
-      <Card 
-        title={`🧑‍💻 ${studentProfile?.name || '冒险者'}`} 
-        subtitle="你的编程冒险档案"
-        style={{ 
+      <Card
+        title={`🧑‍💻 ${studentProfile?.name || '冒险者'}`}
+        subtitle="追踪你的通关记录、星星与装扮收集"
+        style={{
           background: 'linear-gradient(135deg, #8b5cf6 0%, #7c3aed 100%)',
           color: 'white'
         }}
       >
         <div style={{ display: 'flex', gap: '24px', alignItems: 'center', marginTop: '16px' }}>
-          <div style={{ 
+          <div style={{
             fontSize: '4rem',
             background: 'rgba(255,255,255,0.1)',
             borderRadius: '50%',
             padding: '20px',
             backdropFilter: 'blur(10px)'
           }}>
-            {studentProfile?.avatar.equipped === 'starter-cape' ? '🧑‍💻' : 
-             studentProfile?.avatar.equipped === 'wizard-hat' ? '🧙‍♂️' :
-             studentProfile?.avatar.equipped === 'dragon-armor' ? '🛡️' : '👑'}
+            {OUTFITS.find(outfit => outfit.id === studentProfile?.avatar.equipped)?.icon ?? '🧑‍🚀'}
           </div>
           <div style={{ flex: 1 }}>
-            <div style={{ fontSize: '24px', fontWeight: 'bold', marginBottom: '8px' }}>
-              等级 {levelInfo.level} 编程冒险者
+            <div style={{ display: 'flex', gap: '16px', flexWrap: 'wrap' }}>
+              <div>
+                <div style={{ fontSize: '14px', opacity: 0.8 }}>等级</div>
+                <div style={{ fontSize: '32px', fontWeight: 'bold' }}>Lv.{levelInfo.level}</div>
+              </div>
+              <div>
+                <div style={{ fontSize: '14px', opacity: 0.8 }}>累计星星</div>
+                <div style={{ fontSize: '32px', fontWeight: 'bold' }}>{stats.totalStars}</div>
+              </div>
+              <div>
+                <div style={{ fontSize: '14px', opacity: 0.8 }}>连续练习</div>
+                <div style={{ fontSize: '32px', fontWeight: 'bold' }}>{stats.streak} 天</div>
+              </div>
             </div>
-            <div style={{ fontSize: '16px', opacity: 0.9, marginBottom: '12px' }}>
-              经验值: {levelInfo.currentExp}/{levelInfo.maxExp}
-            </div>
-            <Progress 
-              value={levelInfo.progress} 
-              label={`升级进度 ${levelInfo.progress.toFixed(0)}%`}
-              style={{ marginBottom: '12px' }}
-            />
-            <div style={{ display: 'flex', gap: '12px', flexWrap: 'wrap' }}>
-              <Badge tone="success" style={{ background: 'rgba(255,255,255,0.2)' }}>
-                🏆 {stats.completedLevels} 关卡完成
-              </Badge>
-              <Badge tone="warning" style={{ background: 'rgba(255,255,255,0.2)' }}>
-                ⭐ {stats.totalStars} 颗星星
-              </Badge>
-              <Badge tone="info" style={{ background: 'rgba(255,255,255,0.2)' }}>
-                🔥 连续 {stats.streak} 天学习
-              </Badge>
+            <div style={{ marginTop: '12px', background: 'rgba(255,255,255,0.15)', padding: '12px', borderRadius: '12px' }}>
+              <div style={{ fontSize: '14px', marginBottom: '4px' }}>距离下一等级还需 {levelInfo.maxExp - levelInfo.currentExp} 星</div>
+              <Progress value={levelInfo.progress} />
             </div>
           </div>
         </div>
       </Card>
 
-      {/* 标签切换 */}
-      <Card>
-        <div style={{ 
-          display: 'flex', 
-          gap: '8px',
-          borderBottom: '1px solid #e5e7eb',
-          marginBottom: '20px'
-        }}>
-          {[
-            { id: 'achievements', label: '🏆 成就徽章', icon: '🏆' },
-            { id: 'outfits', label: '👔 装扮收集', icon: '👔' },
-            { id: 'stats', label: '📊 学习统计', icon: '📊' }
-          ].map(tab => (
-            <button
-              key={tab.id}
-              onClick={() => setSelectedTab(tab.id as any)}
-              style={{
-                padding: '12px 20px',
-                border: 'none',
-                borderBottom: selectedTab === tab.id ? '2px solid #6366f1' : '2px solid transparent',
-                background: 'none',
-                color: selectedTab === tab.id ? '#6366f1' : '#6b7280',
-                fontSize: '16px',
-                fontWeight: selectedTab === tab.id ? 'bold' : 'normal',
-                cursor: 'pointer',
-                transition: 'all 0.2s ease'
-              }}
-            >
-              {tab.label}
-            </button>
-          ))}
-        </div>
-
-        {/* 成就徽章 */}
+      <Card
+        title="🥇 成就进度"
+        subtitle="根据通关表现解锁徽章"
+        actions={
+          <div style={{ display: 'flex', gap: '8px' }}>
+            <Button size="sm" variant={selectedTab === 'achievements' ? 'primary' : 'secondary'} onClick={() => setSelectedTab('achievements')}>
+              成就
+            </Button>
+            <Button size="sm" variant={selectedTab === 'outfits' ? 'primary' : 'secondary'} onClick={() => setSelectedTab('outfits')}>
+              装扮
+            </Button>
+            <Button size="sm" variant={selectedTab === 'stats' ? 'primary' : 'secondary'} onClick={() => setSelectedTab('stats')}>
+              数据
+            </Button>
+          </div>
+        }
+      >
         {selectedTab === 'achievements' && (
-          <div>
-            <div style={{ marginBottom: '20px', textAlign: 'center' }}>
-              <h3 style={{ color: '#374151', marginBottom: '8px' }}>解锁成就 {ACHIEVEMENTS.filter(achievement => isAchievementUnlocked(achievement)).length}/{ACHIEVEMENTS.length}</h3>
-              <Progress 
-                value={(ACHIEVEMENTS.filter(achievement => isAchievementUnlocked(achievement)).length / ACHIEVEMENTS.length) * 100}
-                label="成就完成度"
-              />
-            </div>
-
-            {ACHIEVEMENTS.length > 0 ? (
-              <div style={{ 
-                display: 'grid', 
-                gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', 
-                gap: '16px' 
-              }}>
-                {ACHIEVEMENTS.map((achievement) => {
-                  const unlocked = isAchievementUnlocked(achievement);
-                  
-                  return (
-                    <div
-                      key={achievement.id}
-                      style={{
-                        padding: '20px',
-                        border: unlocked ? '2px solid #16a34a' : '2px solid #e5e7eb',
-                        borderRadius: '12px',
-                        textAlign: 'center',
-                        background: unlocked ? '#f0fdf4' : '#f9fafb',
-                        opacity: unlocked ? 1 : 0.6,
-                        transition: 'all 0.3s ease'
-                      }}
-                    >
-                      <div style={{ 
-                        fontSize: '3rem', 
-                        marginBottom: '12px',
-                        filter: unlocked ? 'none' : 'grayscale(1)'
-                      }}>
-                        {unlocked ? achievement.icon : '🔒'}
-                      </div>
-                      <h3 style={{ 
-                        margin: '0 0 8px 0', 
-                        fontSize: '18px',
-                        color: unlocked ? '#16a34a' : '#6b7280'
-                      }}>
-                        {achievement.name}
-                      </h3>
-                      <p style={{ 
-                        margin: 0, 
-                        fontSize: '14px', 
-                        color: '#6b7280',
-                        lineHeight: '1.4'
-                      }}>
-                        {achievement.description}
-                      </p>
-                      {unlocked && (
-                        <Badge tone="success" style={{ marginTop: '12px' }}>
-                          ✅ 已解锁
-                        </Badge>
-                      )}
+          <div style={{ display: 'grid', gap: '12px' }}>
+            {ACHIEVEMENTS.map(achievement => {
+              const unlocked = isAchievementUnlocked(achievement);
+              return (
+                <Card key={achievement.id} style={{ border: `2px solid ${unlocked ? '#22c55e' : '#e2e8f0'}` }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+                    <div style={{ fontSize: '2rem' }}>{achievement.icon}</div>
+                    <div style={{ flex: 1 }}>
+                      <div style={{ fontSize: '16px', fontWeight: 'bold', color: '#1f2937' }}>{achievement.name}</div>
+                      <div style={{ fontSize: '14px', color: '#64748b' }}>{achievement.description}</div>
                     </div>
-                  );
-                })}
-              </div>
-            ) : (
-              <EmptyState 
-                title="暂无成就" 
-                description="完成更多关卡来解锁成就吧！"
-              />
-            )}
+                    <Badge tone={unlocked ? 'success' : 'warning'}>{unlocked ? '已解锁' : '未完成'}</Badge>
+                  </div>
+                </Card>
+              );
+            })}
           </div>
         )}
 
-        {/* 装扮收集 */}
         {selectedTab === 'outfits' && (
-          <div>
-            <div style={{ marginBottom: '20px', textAlign: 'center' }}>
-              <h3 style={{ color: '#374151', marginBottom: '8px' }}>
-                收集装扮 {OUTFITS.filter(outfit => isOutfitUnlocked(outfit)).length}/{OUTFITS.length}
-              </h3>
-              <div style={{ fontSize: '14px', color: '#6b7280' }}>
-                当前装备: {OUTFITS.find(outfit => outfit.id === studentProfile?.avatar.equipped)?.name || '未知'}
-              </div>
-            </div>
+          chapters.length === 0 ? (
+            <EmptyState
+              title="暂未解锁新装扮"
+              description="完成更多关卡、收集星星即可解锁限定外观"
+              actions={<Button variant="primary" onClick={() => navigate('/student/levels')}>前往挑战</Button>}
+            />
+          ) : (
+            <div style={{ display: 'grid', gap: '12px' }}>
+              {OUTFITS.map(outfit => {
+                const unlocked = isOutfitUnlocked(outfit.id);
+                const isEquipped = studentProfile?.avatar.equipped === outfit.id;
+                const rarityColor = getRarityColor(outfit.rarity);
 
-            <div style={{ 
-              display: 'grid', 
-              gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', 
-              gap: '16px' 
-            }}>
-              {OUTFITS.map((outfit) => {
-                const unlocked = isOutfitUnlocked(outfit);
-                const equipped = studentProfile?.avatar.equipped === outfit.id;
-                const rarityStyle = getRarityColor(outfit.rarity);
-                
                 return (
                   <div
                     key={outfit.id}
                     style={{
-                      padding: '20px',
-                      border: equipped ? `3px solid ${rarityStyle.border}` : 
-                             unlocked ? `2px solid ${rarityStyle.border}` : '2px solid #e5e7eb',
-                      borderRadius: '12px',
-                      textAlign: 'center',
-                      background: equipped ? rarityStyle.bg : unlocked ? rarityStyle.bg : '#f9fafb',
-                      opacity: unlocked ? 1 : 0.5,
-                      cursor: unlocked ? 'pointer' : 'default',
-                      transition: 'all 0.3s ease',
-                      position: 'relative'
+                      border: `2px solid ${rarityColor.border}`,
+                      background: rarityColor.bg,
+                      borderRadius: '16px',
+                      padding: '16px',
+                      display: 'flex',
+                      flexDirection: 'column',
+                      gap: '8px'
                     }}
                   >
-                    {equipped && (
-                      <div style={{
-                        position: 'absolute',
-                        top: '-10px',
-                        right: '-10px',
-                        background: '#16a34a',
-                        color: 'white',
-                        borderRadius: '50%',
-                        width: '24px',
-                        height: '24px',
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        fontSize: '12px'
-                      }}>
-                        ✓
+                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+                        <span style={{ fontSize: '2rem' }}>{outfit.icon}</span>
+                        <div>
+                          <div style={{ fontSize: '16px', fontWeight: 600, color: rarityColor.text }}>{outfit.name}</div>
+                          <div style={{ fontSize: '13px', color: '#475569' }}>{outfit.description}</div>
+                        </div>
                       </div>
-                    )}
-                    
-                    <div style={{ 
-                      fontSize: '3rem', 
-                      marginBottom: '12px',
-                      filter: unlocked ? 'none' : 'grayscale(1)'
-                    }}>
-                      {unlocked ? outfit.icon : '🔒'}
+                      <Badge tone={isEquipped ? 'success' : unlocked ? 'info' : 'warning'}>
+                        {isEquipped ? '已装备' : unlocked ? '可装备' : '未解锁'}
+                      </Badge>
                     </div>
-                    
-                    <h3 style={{ 
-                      margin: '0 0 4px 0', 
-                      fontSize: '16px',
-                      color: unlocked ? rarityStyle.text : '#6b7280'
-                    }}>
-                      {outfit.name}
-                    </h3>
-                    
-                    <Badge 
-                      tone={
-                        outfit.rarity === 'legendary' ? 'warning' :
-                        outfit.rarity === 'epic' ? 'warning' :
-                        outfit.rarity === 'rare' ? 'info' : 'success'
-                      }
-                      style={{ marginBottom: '8px' }}
-                    >
-                      {outfit.rarity}
-                    </Badge>
-                    
-                    <p style={{ 
-                      margin: '8px 0', 
-                      fontSize: '12px', 
-                      color: '#6b7280',
-                      lineHeight: '1.3'
-                    }}>
-                      {outfit.description}
-                    </p>
-                    
-                    <div style={{ fontSize: '11px', color: '#9ca3af' }}>
-                      解锁条件: {outfit.unlockCondition}
+                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                      <span style={{ fontSize: '12px', color: '#64748b' }}>{outfit.unlockCondition}</span>
+                      {unlocked && !isEquipped && (
+                        <Button
+                          size="sm"
+                          variant="primary"
+                          disabled={equipping === outfit.id}
+                          onClick={() => handleEquipOutfit(outfit.id)}
+                        >
+                          {equipping === outfit.id ? '切换中...' : '装备'}
+                        </Button>
+                      )}
                     </div>
-                    
-                    {equipped && (
-                      <div style={{ 
-                        marginTop: '8px', 
-                        fontSize: '12px', 
-                        color: '#16a34a',
-                        fontWeight: 'bold'
-                      }}>
-                        已装备
-                      </div>
-                    )}
                   </div>
                 );
               })}
             </div>
-          </div>
+          )
         )}
 
-        {/* 学习统计 */}
         {selectedTab === 'stats' && (
-          <div>
-            <div style={{ 
-              display: 'grid', 
-              gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', 
-              gap: '16px',
-              marginBottom: '24px'
-            }}>
-              <div style={{ 
-                textAlign: 'center', 
-                padding: '24px', 
-                background: '#fef3c7', 
-                borderRadius: '12px',
-                border: '2px solid #f59e0b'
-              }}>
-                <div style={{ fontSize: '3rem', color: '#d97706', marginBottom: '8px' }}>🎯</div>
-                <div style={{ fontSize: '2rem', fontWeight: 'bold', color: '#92400e' }}>
-                  {stats.completedLevels}
-                </div>
-                <div style={{ fontSize: '14px', color: '#92400e' }}>关卡完成</div>
+          <div style={{ display: 'grid', gap: '16px' }}>
+            <Card title="学习里程">
+              <div style={{ display: 'grid', gap: '8px' }}>
+                <div>累计完成关卡：{stats.completedLevels}</div>
+                <div>收集星星：{stats.totalStars}</div>
+                <div>练习时长：{Math.round(stats.totalTime / 60)} 分钟</div>
+                <div>连续练习：{stats.streak} 天</div>
               </div>
-              
-              <div style={{ 
-                textAlign: 'center', 
-                padding: '24px', 
-                background: '#dbeafe', 
-                borderRadius: '12px',
-                border: '2px solid #3b82f6'
-              }}>
-                <div style={{ fontSize: '3rem', color: '#2563eb', marginBottom: '8px' }}>⭐</div>
-                <div style={{ fontSize: '2rem', fontWeight: 'bold', color: '#1e40af' }}>
-                  {stats.totalStars}
+            </Card>
+            <Card title="章节进度">
+              {chapters.length === 0 ? (
+                <EmptyState title="暂无进度" description="完成首个关卡后即可查看章节进度" />
+              ) : (
+                <div style={{ display: 'grid', gap: '12px' }}>
+                  {chapters.map(chapter => {
+                    const totalLevels = chapter.levels.length;
+                    const completedLevels = chapter.levels.filter(level => level.status === 'completed').length;
+                    const progressPercent = totalLevels === 0 ? 0 : Math.round((completedLevels / totalLevels) * 100);
+                    return (
+                      <div key={chapter.id}>
+                        <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '4px', color: '#1f2937' }}>
+                          <span>{chapter.title}</span>
+                          <span>{completedLevels}/{totalLevels}</span>
+                        </div>
+                        <Progress value={progressPercent} />
+                      </div>
+                    );
+                  })}
                 </div>
-                <div style={{ fontSize: '14px', color: '#1e40af' }}>获得星星</div>
-              </div>
-              
-              <div style={{ 
-                textAlign: 'center', 
-                padding: '24px', 
-                background: '#dcfce7', 
-                borderRadius: '12px',
-                border: '2px solid #16a34a'
-              }}>
-                <div style={{ fontSize: '3rem', color: '#16a34a', marginBottom: '8px' }}>🔥</div>
-                <div style={{ fontSize: '2rem', fontWeight: 'bold', color: '#15803d' }}>
-                  {stats.streak}
-                </div>
-                <div style={{ fontSize: '14px', color: '#15803d' }}>连续学习天数</div>
-              </div>
-              
-              <div style={{ 
-                textAlign: 'center', 
-                padding: '24px', 
-                background: '#fce7f3', 
-                borderRadius: '12px',
-                border: '2px solid #ec4899'
-              }}>
-                <div style={{ fontSize: '3rem', color: '#be185d', marginBottom: '8px' }}>⏱️</div>
-                <div style={{ fontSize: '2rem', fontWeight: 'bold', color: '#9d174d' }}>
-                  {Math.floor(stats.totalTime / 60)}m
-                </div>
-                <div style={{ fontSize: '14px', color: '#9d174d' }}>总学习时长</div>
-              </div>
-            </div>
-
-            {/* 详细统计 */}
-            <Card title="📈 详细分析" subtitle="深入了解你的学习表现">
-              <div style={{ display: 'grid', gap: '16px' }}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                  <span style={{ color: '#374151' }}>平均每关用时</span>
-                  <span style={{ fontWeight: 'bold', color: '#6366f1' }}>
-                    {stats.completedLevels > 0 ? Math.round(stats.totalTime / stats.completedLevels) : 0}秒
-                  </span>
-                </div>
-                
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                  <span style={{ color: '#374151' }}>平均星级</span>
-                  <span style={{ fontWeight: 'bold', color: '#f59e0b' }}>
-                    {stats.completedLevels > 0 ? (stats.totalStars / stats.completedLevels).toFixed(1) : 0} ⭐
-                  </span>
-                </div>
-                
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                  <span style={{ color: '#374151' }}>3星关卡数</span>
-                  <span style={{ fontWeight: 'bold', color: '#16a34a' }}>
-                    {studentProfile ? 
-                      Object.values(studentProfile.progress).filter(record => record.stars === 3).length 
-                      : 0}
-                  </span>
-                </div>
-                
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                  <span style={{ color: '#374151' }}>解锁成就</span>
-                  <span style={{ fontWeight: 'bold', color: '#8b5cf6' }}>
-                    {ACHIEVEMENTS.filter(achievement => isAchievementUnlocked(achievement)).length}/{ACHIEVEMENTS.length}
-                  </span>
-                </div>
-              </div>
+              )}
             </Card>
           </div>
         )}

--- a/apps/web/src/app/pages/student/LevelDetailPage.tsx
+++ b/apps/web/src/app/pages/student/LevelDetailPage.tsx
@@ -1,34 +1,192 @@
-import { useParams } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 import { Card } from '../../../components/ui/Card';
 import { Tabs, TabItem } from '../../../components/ui/Tabs';
 import { Button } from '../../../components/ui/Button';
+import { Badge } from '../../../components/ui/Badge';
+import { Skeleton } from '../../../components/ui/Skeleton';
+import { useAppStore } from '../../../store/useAppStore';
+import { apiClient, Level } from '../../../services/api/client';
+
+const BLOCK_LABELS: Record<string, string> = {
+  MOVE: '向前移动',
+  TURN_LEFT: '向左转',
+  TURN_RIGHT: '向右转',
+  COLLECT: '收集宝石',
+  REPEAT: '重复循环',
+  CONDITIONAL: '条件判断'
+};
 
 const LevelDetailPage = () => {
   const { levelId } = useParams();
+  const navigate = useNavigate();
+  const { isLoggedIn } = useAppStore();
+
+  const [level, setLevel] = useState<Level | null>(null);
+  const [prep, setPrep] = useState<{ victoryCondition: any; allowedBlocks: string[]; comic?: string; rewards?: any } | null>(null);
+  const [status, setStatus] = useState<'locked' | 'unlocked' | 'completed'>('locked');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!levelId || !isLoggedIn) {
+      return;
+    }
+
+    let cancelled = false;
+    const load = async () => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const [detailResponse, prepResponse] = await Promise.all([
+          apiClient.getStudentLevel(levelId),
+          apiClient.getLevelPrep(levelId)
+        ]);
+
+        if (!cancelled) {
+          if (detailResponse.error) {
+            // 如果关卡未解锁，保留状态并允许展示准备信息
+            if (detailResponse.error.includes('未解锁')) {
+              setStatus('locked');
+            } else {
+              setError(detailResponse.error);
+            }
+          } else if (detailResponse.data) {
+            setLevel(detailResponse.data);
+            setStatus(detailResponse.data.status ?? 'unlocked');
+          }
+
+          if (prepResponse.error) {
+            setError(prepResponse.error);
+          } else if (prepResponse.data) {
+            setPrep(prepResponse.data);
+          }
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : '加载关卡信息失败');
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [levelId, isLoggedIn]);
+
+  if (!isLoggedIn) {
+    return (
+      <Card title="请先登录">
+        <p>登录后即可查看关卡详情。</p>
+        <Button variant="primary" onClick={() => navigate('/auth')}>
+          前往登录
+        </Button>
+      </Card>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div style={{ display: 'grid', gap: '1rem' }}>
+        <Skeleton height={180} />
+        <Skeleton height={320} />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card title="加载失败" subtitle={`关卡 ${levelId}`}>
+        <p style={{ color: '#ef4444', marginBottom: '16px' }}>{error}</p>
+        <Button variant="primary" onClick={() => window.location.reload()}>
+          重试
+        </Button>
+      </Card>
+    );
+  }
+
+  const victoryCondition = prep?.victoryCondition ?? level?.goal;
+  const allowedBlocks = prep?.allowedBlocks ?? level?.allowedBlocks ?? [];
+  const comic = prep?.comic ?? level?.comic;
+  const rewards = prep?.rewards ?? level?.rewards;
 
   return (
-    <Card
-      title={`关卡 ${levelId}`}
-      subtitle="目标、可用积木与教学漫画一屏掌握"
-      actions={<Button variant="primary">进入挑战</Button>}
-    >
-      <Tabs>
-        <TabItem id="goal" title="目标">
-          <p>达成指定路径并在 60 步内完成。</p>
-        </TabItem>
-        <TabItem id="blocks" title="可用积木">
-          <ul>
-            <li>前进</li>
-            <li>向左/向右转</li>
-            <li>重复循环</li>
-            <li>条件判断</li>
-          </ul>
-        </TabItem>
-        <TabItem id="comic" title="教学漫画">
-          <p>漫画占位：讲述小机器人如何学会循环的故事。</p>
-        </TabItem>
-      </Tabs>
-    </Card>
+    <div style={{ display: 'grid', gap: '1.5rem' }}>
+      <Card
+        title={level ? `🎮 ${level.name}` : `关卡 ${levelId}`}
+        subtitle="目标、可用积木与教学漫画一屏掌握"
+        actions={
+          <Button
+            variant="primary"
+            disabled={status === 'locked'}
+            onClick={() => navigate(`/student/play/${levelId}`)}
+          >
+            {status === 'locked' ? '关卡未解锁' : status === 'completed' ? '再次挑战' : '进入挑战'}
+          </Button>
+        }
+      >
+        <div style={{ display: 'flex', gap: '16px', alignItems: 'center', marginBottom: '16px' }}>
+          <Badge tone={status === 'completed' ? 'success' : status === 'locked' ? 'warning' : 'info'}>
+            {status === 'completed' ? '已完成' : status === 'locked' ? '未解锁' : '可挑战'}
+          </Badge>
+          {level?.bestSteps !== undefined && (
+            <span style={{ fontSize: '14px', color: '#64748b' }}>最佳步数：{level.bestSteps}</span>
+          )}
+          {rewards?.outfit && (
+            <Badge tone="info">奖励：{rewards.outfit}</Badge>
+          )}
+        </div>
+
+        <Tabs>
+          <TabItem id="goal" title="任务目标">
+            {victoryCondition ? (
+              <ul style={{ lineHeight: 1.8, color: '#374151' }}>
+                {victoryCondition.reach && (
+                  <li>到达坐标 ({victoryCondition.reach.x}, {victoryCondition.reach.y})</li>
+                )}
+                {victoryCondition.collectibles !== undefined && (
+                  <li>收集 {victoryCondition.collectibles === 0 ? '所有宝石' : `${victoryCondition.collectibles} 件道具`}</li>
+                )}
+                {victoryCondition.stepLimit && (
+                  <li>在 {victoryCondition.stepLimit} 步内完成挑战</li>
+                )}
+              </ul>
+            ) : (
+              <p style={{ color: '#6b7280' }}>暂无目标信息。</p>
+            )}
+          </TabItem>
+
+          <TabItem id="blocks" title="可用积木">
+            {allowedBlocks.length > 0 ? (
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
+                {allowedBlocks.map((block) => (
+                  <Badge key={block} tone="info">
+                    {BLOCK_LABELS[block] ?? block}
+                  </Badge>
+                ))}
+              </div>
+            ) : (
+              <p style={{ color: '#6b7280' }}>该关卡未限制积木类型。</p>
+            )}
+          </TabItem>
+
+          <TabItem id="comic" title="教学漫画">
+            {comic ? (
+              <p style={{ whiteSpace: 'pre-wrap', lineHeight: 1.7, color: '#4b5563' }}>{comic}</p>
+            ) : (
+              <p style={{ color: '#6b7280' }}>本关暂未配置教学漫画。</p>
+            )}
+          </TabItem>
+        </Tabs>
+      </Card>
+    </div>
   );
 };
 

--- a/apps/web/src/app/pages/student/SettingsPage.tsx
+++ b/apps/web/src/app/pages/student/SettingsPage.tsx
@@ -1,61 +1,245 @@
-import { useForm } from 'react-hook-form';
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Controller, useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Card } from '../../../components/ui/Card';
 import { Button } from '../../../components/ui/Button';
-import { Input } from '../../../components/ui/Input';
 import { Select } from '../../../components/ui/Select';
+import { useAppStore } from '../../../store/useAppStore';
+import { apiClient } from '../../../services/api/client';
 
 const settingsSchema = z.object({
-  displayName: z.string().min(2, '昵称至少两个字符'),
-  language: z.string(),
-  enableVoice: z.boolean().default(true),
+  volume: z.number().min(0).max(1),
+  language: z.enum(['zh-CN', 'en-US']),
+  lowMotion: z.boolean(),
+  resettable: z.boolean(),
 });
 
 type SettingsForm = z.infer<typeof settingsSchema>;
 
 const SettingsPage = () => {
+  const navigate = useNavigate();
+  const { isLoggedIn, loadStudentData, user } = useAppStore();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [resetting, setResetting] = useState(false);
+
   const {
     register,
     handleSubmit,
+    control,
+    reset,
     formState: { errors, isSubmitting },
   } = useForm<SettingsForm>({
     resolver: zodResolver(settingsSchema),
     defaultValues: {
-      displayName: '像素冒险家',
+      volume: 0.8,
       language: 'zh-CN',
-      enableVoice: true,
+      lowMotion: false,
+      resettable: true,
     },
   });
 
-  const onSubmit = (values: SettingsForm) => {
-    // eslint-disable-next-line no-console
-    console.log('保存设置', values);
+  useEffect(() => {
+    if (!isLoggedIn) {
+      navigate('/auth');
+      return;
+    }
+
+    const loadSettings = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await apiClient.getStudentSettings();
+        if (response.error) {
+          setError(response.error);
+          return;
+        }
+
+        if (response.data) {
+          reset({
+            volume: typeof response.data.volume === 'number' ? response.data.volume : 0.8,
+            language: response.data.language ?? 'zh-CN',
+            lowMotion: Boolean(response.data.lowMotion),
+            resettable: response.data.resettable ?? true,
+          });
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : '加载设置失败');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    void loadSettings();
+  }, [isLoggedIn, navigate, reset]);
+
+  const onSubmit = async (values: SettingsForm) => {
+    setFeedback(null);
+    setError(null);
+
+    try {
+      const response = await apiClient.updateStudentSettings(values);
+      if (response.error) {
+        setError(response.error);
+        return;
+      }
+      setFeedback('设置已保存，稍后生效。');
+      await loadStudentData();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '保存失败');
+    }
   };
 
+  const handleResetProgress = async () => {
+    setResetting(true);
+    setFeedback(null);
+    setError(null);
+    try {
+      const response = await apiClient.resetStudentProgress();
+      if (response.error) {
+        setError(response.error);
+        return;
+      }
+      setFeedback('已清空关卡进度，可重新开始冒险。');
+      await loadStudentData();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '重置进度失败');
+    } finally {
+      setResetting(false);
+    }
+  };
+
+  if (!isLoggedIn) {
+    return null;
+  }
+
+  if (loading) {
+    return (
+      <Card title="加载中">
+        <p style={{ color: '#6b7280' }}>正在获取你的设置...</p>
+      </Card>
+    );
+  }
+
   return (
-    <Card title="学生设置" subtitle="调节语音提示、语言、昵称等">
-      <form onSubmit={handleSubmit(onSubmit)} style={{ display: 'grid', gap: '1rem', maxWidth: '420px' }}>
-        <label>
-          <span>昵称</span>
-          <Input {...register('displayName')} />
-          {errors.displayName ? <span style={{ color: '#ef4444' }}>{errors.displayName.message}</span> : null}
-        </label>
-        <label>
-          <span>界面语言</span>
-          <Select {...register('language')}>
-            <option value="zh-CN">中文</option>
-            <option value="en-US">English</option>
-          </Select>
-        </label>
-        <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-          <input type="checkbox" {...register('enableVoice')} /> 启用语音提示
-        </label>
-        <Button type="submit" disabled={isSubmitting}>
-          保存设置
-        </Button>
-      </form>
-    </Card>
+    <div style={{ display: 'grid', gap: '1.5rem', maxWidth: '680px' }}>
+      <Card
+        title="学生设置"
+        subtitle="调整音量、语言与动效偏好，保存后将在下一次关卡中生效"
+      >
+        <form onSubmit={handleSubmit(onSubmit)} style={{ display: 'grid', gap: '1.25rem' }}>
+          <section>
+            <h3 style={{ margin: '0 0 8px 0', color: '#111827' }}>基础信息</h3>
+            <p style={{ margin: 0, color: '#6b7280' }}>当前昵称：{user?.name ?? '冒险者'}</p>
+          </section>
+
+          <section>
+            <h3 style={{ margin: '0 0 8px 0', color: '#111827' }}>音效设置</h3>
+            <div style={{ display: 'grid', gap: '0.75rem' }}>
+              <Controller
+                name="volume"
+                control={control}
+                render={({ field }) => (
+                  <label style={{ display: 'grid', gap: '4px' }}>
+                    <span>提示音量 ({Math.round((field.value ?? 0) * 100)}%)</span>
+                    <input
+                      type="range"
+                      min={0}
+                      max={100}
+                      value={Math.round((field.value ?? 0) * 100)}
+                      onChange={(event) => field.onChange(Number(event.target.value) / 100)}
+                    />
+                  </label>
+                )}
+              />
+              {errors.volume ? <span style={{ color: '#ef4444' }}>{errors.volume.message}</span> : null}
+            </div>
+          </section>
+
+          <section>
+            <h3 style={{ margin: '0 0 8px 0', color: '#111827' }}>显示与语言</h3>
+            <label style={{ display: 'grid', gap: '4px' }}>
+              <span>界面语言</span>
+              <Select {...register('language')}>
+                <option value="zh-CN">中文</option>
+                <option value="en-US">English</option>
+              </Select>
+            </label>
+
+            <Controller
+              name="lowMotion"
+              control={control}
+              render={({ field }) => (
+                <label style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', marginTop: '12px' }}>
+                  <input
+                    type="checkbox"
+                    checked={field.value}
+                    onChange={(event) => {
+                      setFeedback(null);
+                      setError(null);
+                      field.onChange(event.target.checked);
+                    }}
+                  />
+                  <span style={{ color: '#374151' }}>低动效模式（减少动画，保护视力）</span>
+                </label>
+              )}
+            />
+          </section>
+
+          <section>
+            <h3 style={{ margin: '0 0 8px 0', color: '#111827' }}>安全与重置</h3>
+            <Controller
+              name="resettable"
+              control={control}
+              render={({ field }) => (
+                <label style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+                  <input
+                    type="checkbox"
+                    checked={field.value}
+                    onChange={(event) => {
+                      setFeedback(null);
+                      setError(null);
+                      field.onChange(event.target.checked);
+                    }}
+                  />
+                  <span style={{ color: '#374151' }}>允许课堂老师帮助我重置进度</span>
+                </label>
+              )}
+            />
+
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={handleResetProgress}
+              disabled={resetting}
+              style={{ marginTop: '12px' }}
+            >
+              {resetting ? '正在重置...' : '清空关卡进度'}
+            </Button>
+          </section>
+
+          {error && <div style={{ color: '#ef4444' }}>{error}</div>}
+          {feedback && <div style={{ color: '#16a34a' }}>{feedback}</div>}
+
+          <div style={{ display: 'flex', gap: '12px' }}>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? '保存中...' : '保存设置'}
+            </Button>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => reset()}
+              disabled={isSubmitting}
+            >
+              恢复默认
+            </Button>
+          </div>
+        </form>
+      </Card>
+    </div>
   );
 };
 

--- a/apps/web/src/services/api/client.ts
+++ b/apps/web/src/services/api/client.ts
@@ -34,6 +34,15 @@ export interface StudentProfile extends User {
   progress: Record<string, any>;
 }
 
+export interface StudentLevelProgress {
+  levelId: string;
+  stars: number;
+  steps: number;
+  hints: number;
+  duration: number;
+  bestDifference: number;
+}
+
 export interface Level {
   id: string;
   name: string;
@@ -52,6 +61,9 @@ export interface Level {
   allowedBlocks?: string[];
   comic?: string;
   rewards?: { outfit?: string };
+  chapterId?: string;
+  status?: 'locked' | 'unlocked' | 'completed';
+  progress?: StudentLevelProgress | null;
 }
 
 export interface Chapter {
@@ -190,6 +202,10 @@ class ApiClient {
     return this.get(`/student/levels/${levelId}/prep`);
   }
 
+  async getStudentLevel(levelId: string): Promise<ApiResponse<Level>> {
+    return this.get(`/student/levels/${levelId}`);
+  }
+
   async runLevel(levelId: string, program: any[]): Promise<ApiResponse<any>> {
     return this.post(`/student/levels/${levelId}/run`, { program });
   }
@@ -209,8 +225,24 @@ class ApiClient {
     return this.post(`/student/hints/${levelId}`, payload);
   }
 
+  async getStudentSettings(): Promise<ApiResponse<any>> {
+    return this.get('/student/settings');
+  }
+
   async updateStudentSettings(settings: any): Promise<ApiResponse<any>> {
     return this.put('/student/settings', settings);
+  }
+
+  async resetStudentProgress(): Promise<ApiResponse<void>> {
+    return this.post('/student/settings/reset-progress');
+  }
+
+  async getStudentAvatar(): Promise<ApiResponse<{ equipped: string; unlocked: string[] }>> {
+    return this.get('/student/avatar');
+  }
+
+  async updateStudentAvatar(equipped: string): Promise<ApiResponse<{ equipped: string; unlocked: string[] }>> {
+    return this.put('/student/avatar', { equipped });
   }
 
   // 教师端API (基础结构)

--- a/docs/前端页面评测.md
+++ b/docs/前端页面评测.md
@@ -1,0 +1,73 @@
+# 前端页面交互与样式评测报告
+
+> 依据现有 React 前端代码，对主要页面的交互流程、视觉一致性与可访问性进行评估，并给出整改建议。
+
+## 1. 总览
+
+* **技术栈**：React 18 + Zustand + 自建 UI 组件库，页面内大量使用内联样式。
+* **状态管理**：`useAppStore` 负责学生端登录与关卡状态，但教师/家长/管理员页面基本未接入全局状态或 API 数据。【F:apps/web/src/store/useAppStore.ts†L19-L204】【F:apps/web/src/app/pages/teacher/OverviewPage.tsx†L35-L189】
+* **可访问性**：Button 组件无 `:focus` 样式，存在键盘可用性隐患；部分颜色对比未经过统一主题管理。【F:apps/web/src/components/ui/button.css†L1-L33】
+* **响应式**：多处使用固定宽度（如 `gridTemplateColumns: '1fr 400px'`），缺少断点适配。【F:apps/web/src/app/pages/student/PlayPage.tsx†L180-L189】
+
+## 2. 学生端页面评测
+
+### 2.1 首页与地图
+
+* `HomePage` 依赖 `Math.random()` 模拟连续学习天数，导致刷新即变更，缺少真实进度来源。【F:apps/web/src/app/pages/student/HomePage.tsx†L75-L89】
+* `LevelsPage` 预设 `completed/unlocked/locked` 三种状态，但实际接口只返回两种；筛选条件与 Badge 色值硬编码，未来拓展困难。【F:apps/web/src/app/pages/student/LevelsPage.tsx†L12-L114】【F:services/api/src/index.ts†L384-L423】
+* 建议：在 store 中增加“今日学习”统计缓存；引入配置化状态枚举与颜色映射表，避免散落的 inline 样式。
+
+### 2.2 关卡游玩（PlayPage）
+
+* 关卡数据来源为 `/levels/sample-1.json`，若服务器未托管该静态文件则直接报错，且与 API `Level` 定义不完全一致。【F:apps/web/src/app/pages/student/PlayPage.tsx†L54-L112】
+* 右侧控制面板宽度固定 400px，不适配窄屏；按钮区均为 inline 样式，缺少复用组件/主题色变量。【F:apps/web/src/app/pages/student/PlayPage.tsx†L151-L199】
+* 提示流程只在 `getHint` 后弹出 Modal，无提示分级或动画联动，未覆盖设计中的渐进策略。【F:apps/web/src/app/pages/student/PlayPage.tsx†L95-L187】
+* 建议：
+  * 将关卡数据改为 `apiClient.getStudentMap` + `getLevelPrep` 组合，增加错误 Toast。
+  * 使用 CSS 模块/类名替换大量 inline 样式，提供响应式断点。
+  * 引入提示队列和高亮动画（例如通过 `GameCanvas` 暴露 `highlightTiles`）。
+
+### 2.3 Block Editor 与 Canvas
+
+* BlockEditor 组件以 `<style>` 内嵌方式定义布局，缺乏可复用样式文件；循环次数、条件均为硬编码，阻碍教学策略调整。【F:apps/student/src/BlockEditor.tsx†L52-L173】
+* `GameCanvas` 仅采用 Canvas 2D 网格渲染，没有胜利/失败动效或音效钩子，也未暴露手势操作能力。【F:apps/student/src/GameCanvas.tsx†L18-L120】
+* 建议：抽离 CSS，增加参数编辑 UI，Canvas 中提供事件回调供 PlayPage 实现动效与配色切换。
+
+### 2.4 成就、设置等
+
+* `AchievementsPage` 与 `SettingsPage` 均使用本地默认值；设置保存只是 `console.log`，缺少成功提示与错误重试。【F:apps/web/src/app/pages/student/AchievementsPage.tsx†L68-L168】【F:apps/web/src/app/pages/student/SettingsPage.tsx†L22-L36】
+* 建议：接入 `useMutation` 提交后端，加入 Skeleton/Toast，并将随机值改为真实统计。
+
+## 3. 教师端页面评测
+
+* `OverviewPage` 虽调用 API，但渲染层完全依赖 `mockStats` 等常量，实际接口数据未展示；缺乏空数据提示与异常处理。【F:apps/web/src/app/pages/teacher/OverviewPage.tsx†L35-L189】
+* `AssignmentsPage`、`ContentPage`、`AnalyticsPage` 皆为静态表格或 EmptyState，占位文案未与交互绑定；按钮点击无路由跳转或抽屉数据来源。【F:apps/web/src/app/pages/teacher/AssignmentsPage.tsx†L8-L42】【F:apps/web/src/app/pages/teacher/ContentPage.tsx†L8-L37】【F:apps/web/src/app/pages/teacher/AnalyticsPage.tsx†L1-L13】
+* `TeacherLayout` 中 Feature Flag 仅控制抽屉宽度，但无界面入口让运营切换标记；建议提供 Flag 面板或采用远端配置。【F:apps/web/src/app/pages/teacher/TeacherLayout.tsx†L9-L33】【F:apps/web/src/utils/featureFlags.ts†L1-L4】
+
+## 4. 家长端页面评测
+
+* 所有页面（Home/Progress/Settings）均为静态文本或表单占位，未调用 `/parent/children` 系列接口；进度图表和错题集缺失。【F:apps/web/src/app/pages/parent/HomePage.tsx†L5-L17】【F:apps/web/src/app/pages/parent/ProgressPage.tsx†L9-L20】【F:apps/web/src/app/pages/parent/SettingsPage.tsx†L11-L36】
+* 建议：实现孩子选择器 → 加载进度/周报 → 支持导出 PDF；设置页提交后弹出反馈。
+
+## 5. 管理端页面评测
+
+* Admin 模块的 Overview/Users/Curriculum/Ops 皆依赖硬编码数组与 EmptyState，未对接 `/api/admin/*`、`/api/admin/assets` 等接口，按钮操作无副作用。【F:apps/web/src/app/pages/admin/OverviewPage.tsx†L1-L14】【F:apps/web/src/app/pages/admin/UsersPage.tsx†L8-L40】【F:apps/web/src/app/pages/admin/CurriculumPage.tsx†L5-L10】【F:apps/web/src/app/pages/admin/OpsPage.tsx†L6-L23】
+* 建议：
+  * 使用 React Query 统一数据获取，提供加载/错误占位。
+  * 给“编辑”“创建”按钮添加表单或 Drawer，与素材管理、账号管理 API 连通。
+
+## 6. 共享 UI 组件建议
+
+* 按钮与卡片组件虽有基础样式，但缺乏主题/尺寸体系，建议引入 design token（色值、间距）与 variant 规范，避免重复 inline style。【F:apps/web/src/components/ui/Button.tsx†L13-L28】【F:apps/web/src/components/ui/button.css†L1-L33】【F:apps/web/src/components/ui/Card.tsx†L7-L22】
+* Skeleton、EmptyState、Modal 等组件未统一在一个命名空间下维护故事板/示例，影响设计一致性。建议补充 Storybook 或文档。
+
+## 7. 优先整改列表
+
+1. **接入真实数据**：PlayPage/OverviewPage/Parent 模块优先替换 mock 数据，保证核心流程可 demo。【F:apps/web/src/app/pages/student/PlayPage.tsx†L54-L112】【F:apps/web/src/app/pages/teacher/OverviewPage.tsx†L35-L189】【F:apps/web/src/app/pages/parent/HomePage.tsx†L5-L17】
+2. **样式系统化**：提取 inline 样式到 CSS/SCSS 模块，增加响应式断点与 `:focus` 状态，满足设计规范。【F:apps/web/src/app/pages/student/PlayPage.tsx†L151-L199】【F:apps/web/src/components/ui/button.css†L1-L33】
+3. **提示与动效**：根据 `computeHint` 结果展示分级提示，并在 GameCanvas 加入成功/失败动画钩子，提升教学反馈。【F:apps/web/src/app/pages/student/PlayPage.tsx†L95-L187】【F:apps/student/src/GameCanvas.tsx†L18-L120】
+4. **后台操作闭环**：为教师/管理员页面补充抽屉表单、批量操作与错误处理，确保按钮非摆设。【F:apps/web/src/app/pages/teacher/AssignmentsPage.tsx†L8-L42】【F:apps/web/src/app/pages/admin/UsersPage.tsx†L8-L40】
+
+---
+
+通过以上整改，可使前端界面从“展示型原型”迈向“可真实联调的教学平台”，同时满足设计文档中的交互闭环要求。

--- a/docs/未完成功能清单.md
+++ b/docs/未完成功能清单.md
@@ -1,0 +1,48 @@
+# 未完成功能清单（2025-版需求对照）
+
+> 依据《设计方案.md》v1.0 的全端需求，对代码仓库现状进行逐项核查，标记尚未完成或仍为占位实现的功能，供下一步排期与交付评审参考。【F:docs/设计方案.md†L70-L152】
+
+## 学生端（Web）
+
+| 模块 | 设计期望 | 当前状态 | 影响与建议 |
+| --- | --- | --- | --- |
+| 关卡运行（Play） | 关卡数据来自后端 `/student/levels/:id/run`，并串联准备→游玩→结算流程。【F:docs/设计方案.md†L72-L81】 | 页面直接从 `/levels/sample-1.json` 读取本地示例，未调用真实 API；缺少对 `setProgram` 的接入，导致页面无法加载或与后端数据脱节。【F:apps/web/src/app/pages/student/PlayPage.tsx†L54-L112】 | 需要替换为调用 `apiClient.getStudentMap`/`getLevelPrep` 返回的真实关卡对象，并处理 404/锁定态，确保首关与后续关卡可联调。 |
+| 冒险地图状态 | 地图需呈现“解锁→可挑战→已完成”的进度，并驱动下一关按钮。【F:docs/设计方案.md†L72-L78】 | API 仅返回 `completed`/`locked`；前端仍以 `unlocked` 状态过滤，导致所有未完成关卡被判定为“未解锁”。【F:services/api/src/index.ts†L384-L423】【F:apps/web/src/app/pages/student/LevelsPage.tsx†L12-L114】 | 后端需计算下一关的可挑战状态（或前端本地推导）；前端过滤条件与状态枚举需同步修正。 |
+| 关卡准备与详情 | 需展示胜利条件、可用积木、教学漫画等真实内容。【F:docs/设计方案.md†L74-L81】 | LevelDetailPage 完全写死静态文案，没有消费 `getLevelPrep` 返回的数据，也缺少教学漫画展示容器。【F:apps/web/src/app/pages/student/LevelDetailPage.tsx†L9-L24】 | 将准备页改为调用接口并渲染 `victoryCondition`、`allowedBlocks`、`comic` 字段；补充骨架状态与错误处理。 |
+| Block Editor 积木能力 | 需要支持循环次数、条件等参数编辑，对应 Hint 策略。【F:docs/设计方案.md†L104-L123】 | `repeat` 固定次数为 3，条件积木同样硬编码，缺少 UI 让学生调整指令或填充嵌套块。【F:apps/student/src/BlockEditor.tsx†L52-L139】 | 设计参数编辑面板，或引入可配置弹窗，至少允许循环次数/条件下拉选择。 |
+| 结算页 | 需展示星级、奖励、最佳差距和下一步 CTA。【F:docs/设计方案.md†L75-L78】 | ResultPage 为纯静态占位，未与 `completeLevel` 结果或奖励挂钩，也未在 PlayPage 内触发实际弹窗逻辑。【F:apps/web/src/app/pages/student/ResultPage.tsx†L1-L22】【F:apps/web/src/app/pages/student/PlayPage.tsx†L100-L117】 | 将结算逻辑整合进 PlayPage（或单独路由）并渲染 `simulationResult` 返回值；调用 `/student/levels/:id/complete` 后根据响应展示奖励。 |
+| 设置/语音 | 需可保存音量、语言、低动效等设置并回写后端。【F:docs/设计方案.md†L79-L81】 | SettingsPage 仅在控制台输出，缺少与 `apiClient.updateStudentSettings` 的交互以及成功/失败反馈。【F:apps/web/src/app/pages/student/SettingsPage.tsx†L30-L36】 | 使用 `useAppStore`/React Query 提交设置，增加保存中/保存成功提示与错误处理。 |
+| 成就与装扮 | 应基于真实进度数据计算、展示来源说明。【F:docs/设计方案.md†L77-L78】【F:docs/设计方案.md†L145-L150】 | AchievementsPage 用 `Math.random()` 伪造连续天数，装扮/成就条件写死且未与 `/student/avatar`、`/compendium` 等接口同步；缺少获取/换装动作。【F:apps/web/src/app/pages/student/AchievementsPage.tsx†L68-L168】 | 改为读取 `studentProfile` 与奖励配置；实现装扮切换/图鉴解锁 API；展示真实来源文案。 |
+
+## 教师端
+
+| 模块 | 设计期望 | 当前状态 | 影响与建议 |
+| --- | --- | --- | --- |
+| 认证入口 | 教师账号需通过邮箱/密码或单点方式登录后访问后台。【F:docs/设计方案.md†L83-L89】 | AuthPage 中教师/家长 Tab 被禁用，按钮标记“暂未开放”。【F:apps/web/src/app/pages/shared/AuthPage.tsx†L170-L236】 | 需实现教师/家长登录流程（API 或临时模拟），并在路由守卫中根据角色分流。 |
+| 概览看板 | 展示真实班级、学生、关卡、掌握度数据。【F:docs/设计方案.md†L85-L89】 | OverviewPage 虽调用 API，但界面渲染完全来自 `mockStats`/`mockConcepts`/`mockAlerts`，未消费接口响应值；无错误提示。【F:apps/web/src/app/pages/teacher/OverviewPage.tsx†L35-L189】 | 替换 mock 为接口返回的真实结构，若暂无数据需优雅降级；补充加载/错误状态。 |
+| 作业布置、内容管理 | 需对接课程、章节、关卡 CRUD。【F:docs/设计方案.md†L85-L87】 | AssignmentsPage/ContentPage 仅渲染硬编码数组和占位 Drawer，无检索、批量操作或 API 调用。【F:apps/web/src/app/pages/teacher/AssignmentsPage.tsx†L8-L42】【F:apps/web/src/app/pages/teacher/ContentPage.tsx†L8-L37】 | 建立与 `/api/teacher/courses*`、`/chapters`、`/levels` 的数据流，提供增删改查与抽屉详情。 |
+| 进度分析 | 应包含热力图、卡关榜、回放入口。【F:docs/设计方案.md†L88-L89】 | AnalyticsPage 全为 EmptyState，占位文案提示“等待数据接入”，未显示任何图表或链接。【F:apps/web/src/app/pages/teacher/AnalyticsPage.tsx†L1-L13】 | 接入 `/teacher/analytics/*` 接口，渲染统计卡片和图表，可嵌入回放跳转。 |
+
+## 家长端
+
+| 模块 | 设计期望 | 当前状态 | 影响与建议 |
+| --- | --- | --- | --- |
+| 首页与进度页 | 应展示孩子真实进度、常见错误、周报下载。【F:docs/设计方案.md†L91-L94】 | HomePage/ProgressPage 使用固定文本与占位组件，未连接 `/parent/children`、`/progress`、`/weekly-report`；错题集等信息缺失。【F:apps/web/src/app/pages/parent/HomePage.tsx†L5-L17】【F:apps/web/src/app/pages/parent/ProgressPage.tsx†L9-L20】 | 调用相关 API，加入子女选择器、下载按钮与错题列表；提供无数据的空状态。 |
+| 家长设置 | 需保存提醒时间、家校沟通偏好等配置。【F:docs/设计方案.md†L91-L94】 | SettingsPage 仅 `console.log`，没有提交接口或结果提示。【F:apps/web/src/app/pages/parent/SettingsPage.tsx†L11-L36】 | 建议引入表单验证、提交状态与成功 Toast，同时对接后端存储。 |
+
+## 管理端
+
+| 模块 | 设计期望 | 当前状态 | 影响与建议 |
+| --- | --- | --- | --- |
+| 运营/指标 | 需呈现真实活跃度、素材、账号、导出数据。【F:docs/设计方案.md†L83-L89】 | Overview/Users/Curriculum/Ops 页面均填充硬编码数组或 EmptyState，占位按钮无后续逻辑。【F:apps/web/src/app/pages/admin/OverviewPage.tsx†L1-L14】【F:apps/web/src/app/pages/admin/UsersPage.tsx†L8-L40】【F:apps/web/src/app/pages/admin/CurriculumPage.tsx†L5-L10】【F:apps/web/src/app/pages/admin/OpsPage.tsx†L6-L23】 | 与 `/api/admin/*`、`/api/teacher/works` 等接口对接，补齐增删改查和导出下载；在无权限或无数据时给出反馈。 |
+
+## 跨端与基础能力
+
+| 项 | 设计期望 | 当前状态 | 建议 |
+| --- | --- | --- | --- |
+| Hint & 动画策略 | 根据失败次数提供不同级别提示，并配合动效反馈。【F:docs/设计方案.md†L112-L123】 | PlayPage 未实现提示分层或动效；只是在 `getHint` 后简单弹出模态，且没有语音/动画实现。【F:apps/web/src/app/pages/student/PlayPage.tsx†L95-L187】 | 结合 `computeHint` 结果区分提示类型，加入高亮与语音占位；引入 Lottie/Pixi 等动效方案。 |
+| 响应式与样式体系 | 需要统一风格、支持低动效模式。【F:docs/设计方案.md†L96-L100】 | 大量页面使用内联样式与固定宽度（如 PlayPage 右侧 400px 面板），Button 缺少 `:focus` 状态，低动效模式未实现。【F:apps/web/src/app/pages/student/PlayPage.tsx†L180-L189】【F:apps/web/src/components/ui/button.css†L1-L33】 | 引入设计系统（CSS 变量/Theme Provider），补充焦点样式与媒体查询；在设置页调节低动效模式。 |
+
+---
+
+以上功能需在进入下一里程碑前列入迭代计划，优先解决“真实数据接入”与“核心流程可用性”问题，再逐步补齐动效、个性化与后台管理能力。


### PR DESCRIPTION
## Summary
- surface student map unlock logic on the API and expose a level detail endpoint for the web app
- replace student play, level detail, settings, and achievements pages with API-driven implementations and enhanced UI logic
- extend the shared store, API client, and block editor to support configurable programs, settings persistence, and avatar switching

## Testing
- npm run build *(fails: existing TypeScript typing gaps in UI components and legacy test harness imports)*

------
https://chatgpt.com/codex/tasks/task_e_68d7a2c877888333a4ada56c5d1d52d7