### PR TITLE
Fix student navigation interactions and button defaults

### DIFF
--- a/frontend/apps/web/src/app/pages/student/HomePage.tsx
+++ b/frontend/apps/web/src/app/pages/student/HomePage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useNavigate, Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { Card } from '../../../components/ui/Card';
 import { Button } from '../../../components/ui/Button';
 import { Progress } from '../../../components/ui/Progress';
@@ -332,31 +332,62 @@ const HomePage = () => {
         gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', 
         gap: '1rem' 
       }}>
-        <Card title="🗺️ 关卡地图" subtitle="查看所有可用关卡">
-          <Link to="/student/levels" style={{ textDecoration: 'none', width: '100%', display: 'block' }}>
-            <Button 
-              variant="primary" 
-              style={{ width: '100%' }}
-              onClick={(e) => {
-                console.log('[HomePage] 关卡地图按钮被点击');
-                console.log('[HomePage] Link to: /student/levels');
-              }}
-            >
-              查看地图
-            </Button>
-          </Link>
+        <Card
+          title="🗺️ 关卡地图"
+          subtitle="查看所有可用关卡"
+          role="button"
+          tabIndex={0}
+          onClick={() => {
+            console.log('[HomePage] 关卡地图卡片被点击');
+            navigate('/student/levels');
+          }}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              navigate('/student/levels');
+            }
+          }}
+        >
+          <Button
+            variant="primary"
+            style={{ width: '100%' }}
+            onClick={(event) => {
+              event.stopPropagation();
+              console.log('[HomePage] 关卡地图按钮被点击');
+              navigate('/student/levels');
+            }}
+          >
+            查看地图
+          </Button>
         </Card>
-        
-        <Card title="🏆 成就收集" subtitle="查看获得的徽章和装扮">
-          <Link to="/student/achievements" style={{ textDecoration: 'none', width: '100%', display: 'block' }}>
-            <Button 
-              variant="primary" 
-              style={{ width: '100%' }}
-              onClick={() => console.log('[HomePage] 成就收集按钮被点击')}
-            >
-              查看成就
-            </Button>
-          </Link>
+
+        <Card
+          title="🏆 成就收集"
+          subtitle="查看获得的徽章和装扮"
+          role="button"
+          tabIndex={0}
+          onClick={() => {
+            console.log('[HomePage] 成就收集卡片被点击');
+            navigate('/student/achievements');
+          }}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              navigate('/student/achievements');
+            }
+          }}
+        >
+          <Button
+            variant="primary"
+            style={{ width: '100%' }}
+            onClick={(event) => {
+              event.stopPropagation();
+              console.log('[HomePage] 成就收集按钮被点击');
+              navigate('/student/achievements');
+            }}
+          >
+            查看成就
+          </Button>
         </Card>
         
         {studentProfile?.sandboxUnlocked && (

--- a/frontend/apps/web/src/components/ui/Button.tsx
+++ b/frontend/apps/web/src/components/ui/Button.tsx
@@ -18,11 +18,13 @@ export const Button = ({
   size = 'md',
   loading = false,
   disabled,
+  type = 'button',
   ...rest
 }: PropsWithChildren<ButtonProps>) => (
   <button
     className={clsx('ui-button', `ui-button--${variant}`, `ui-button--${size}`)}
     disabled={loading || disabled}
+    type={type}
     {...rest}
   >
     {loading ? '处理中…' : children}


### PR DESCRIPTION
## Summary
- default Button component to type="button" so non-form clicks no longer trigger unintended submissions
- make the student home quick-access cards keyboard and click navigable via explicit navigation handlers

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68dbf6c319048333b205948918f09bab