### PR TITLE
Fix student home level entry navigation

### DIFF
--- a/frontend/apps/web/src/app/pages/student/HomePage.tsx
+++ b/frontend/apps/web/src/app/pages/student/HomePage.tsx
@@ -194,13 +194,13 @@ const HomePage = () => {
         subtitle="从上次停下的地方继续你的冒险"
         actions={
           nextLevel ? (
-            <Button 
+            <Button
               variant="primary"
               onClick={(e) => {
                 console.log('[HomePage] 进入关卡按钮被点击');
                 console.log('[HomePage] 下一关卡:', nextLevel);
-                console.log('[HomePage] 准备导航到:', `/student/levels/${nextLevel.level}`);
-                navigate(`/student/levels/${nextLevel.level}`);
+                console.log('[HomePage] 准备导航到:', `/student/play/${nextLevel.level}`);
+                navigate(`/student/play/${nextLevel.level}`);
               }}
             >
               进入关卡


### PR DESCRIPTION
## Summary
- update the student home "进入关卡" button to route directly to the play page
- ensure players land on the programming interface which triggers the level detail and prep API calls

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc7431cb608333badb5f6da2584843