### PR TITLE
Fix repeated redirect triggered by auth modal

### DIFF
--- a/frontend/apps/web/src/app/components/AuthModal.tsx
+++ b/frontend/apps/web/src/app/components/AuthModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '../../components/ui/Button';
 import { Input } from '../../components/ui/Input';
@@ -81,8 +81,13 @@ export const AuthModal = () => {
     }
   }, [error]);
 
+  const previousLoginState = useRef(isLoggedIn);
+
   useEffect(() => {
-    if (isLoggedIn && user) {
+    const wasLoggedIn = previousLoginState.current;
+    previousLoginState.current = isLoggedIn;
+
+    if (!wasLoggedIn && isLoggedIn && user) {
       navigate(`/${user.role}`, { replace: true });
     }
   }, [isLoggedIn, user, navigate]);


### PR DESCRIPTION
## Summary
- update the auth modal's login redirect to only trigger when the user transitions from logged out to logged in
- prevent subsequent profile refreshes from sending students back to the home page after navigating to other screens

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dcb12f550c8333bc3f3fb22e5574ff